### PR TITLE
Fix dataset helpers and plotting

### DIFF
--- a/monstim_signals/core/utils.py
+++ b/monstim_signals/core/utils.py
@@ -5,7 +5,10 @@ from typing import List
 import yaml
 from pathlib import Path
 
-from PyQt6.QtWidgets import QApplication
+try:
+    from PyQt6.QtWidgets import QApplication
+except Exception:  # Allow headless environments
+    QApplication = None
 import numpy as np
 from monstim_signals.core.version import __version__
 

--- a/monstim_signals/io/repositories.py
+++ b/monstim_signals/io/repositories.py
@@ -187,6 +187,7 @@ class DatasetRepository:
         dataset = Dataset(
             dataset_id=self.dataset_id,
             sessions=sessions,
+            annot=dataset_annot,
             repo=self
         )
         return dataset
@@ -197,6 +198,7 @@ class DatasetRepository:
         (If I want dataset‐level annotations in the future, write them here.)
         This is called when the user edits any session's recordings.
         """
+        self.dataset_js.write_text(json.dumps(asdict(dataset.annot), indent=2))
         for session in dataset.sessions:
             session.repo.save(session)
 

--- a/monstim_signals/plotting/base_plotter.py
+++ b/monstim_signals/plotting/base_plotter.py
@@ -1,5 +1,8 @@
 import matplotlib.pyplot as plt
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+try:
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+except Exception:  # Fallback when Qt bindings are unavailable
+    from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from typing import TYPE_CHECKING, List
 
 if TYPE_CHECKING:

--- a/monstim_signals/plotting/dataset_plotter.py
+++ b/monstim_signals/plotting/dataset_plotter.py
@@ -339,16 +339,16 @@ class DatasetPlotter(BasePlotter):
             m_max_amplitudes = []
             m_max_thresholds = []
             session_ids = []
-            for session in self.emg_object.emg_sessions:
+            for session in self.emg_object.sessions:
                 try:
                     m_max, mmax_low_stim, _ = session.get_m_max(method=method, channel_index=channel_index, return_mmax_stim_range=True)
                     m_max_amplitudes.append(m_max)
                     m_max_thresholds.append(mmax_low_stim)
-                    session_ids.append(session.session_id)
+                    session_ids.append(session.id)
                 except IndexError:
                     m_max_amplitudes.append(np.nan)
                     m_max_thresholds.append(np.nan)
-                    session_ids.append(session.session_id)
+                    session_ids.append(session.id)
                 
             # Append M-wave amplitudes to superlist for y-axis adjustment.
             all_m_max_amplitudes.extend(m_max_amplitudes)            


### PR DESCRIPTION
## Summary
- refine Dataset config and session helpers
- update DatasetPlotter to use Dataset.sessions and session.id
- fall back to Agg canvas in BasePlotter
- allow headless utils import without PyQt6
- drop dataset_id alias and compute dataset properties dynamically

## Testing
- `pip install numpy h5py matplotlib pandas pyyaml scipy`
- `python - <<'PY'
from pathlib import Path
from monstim_signals.io.repositories import DatasetRepository
path = Path('data_store/EMG-only data/240829 C328.1 post-dec mcurve_long-')
ds = DatasetRepository(path).load()
print('Dataset loaded:', ds.id, len(ds.sessions))
print('Channels:', ds.channel_names)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6842f2b1225883258621db9f11740be3