### PR TITLE
Fix ExperimentPlotter for new Experiment class

### DIFF
--- a/monstim_signals/domain/experiment.py
+++ b/monstim_signals/domain/experiment.py
@@ -127,6 +127,39 @@ class Experiment:
         self._all_datasets = [ds for ds in self._all_datasets if ds.id != dataset_id]
         self.reset_all_caches()
 
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _aggregate_wave_amplitudes(self, method: str, channel_index: int,
+                                   amplitude_func) -> tuple[list[float], list[float]]:
+        """Aggregate amplitudes across datasets.
+
+        Parameters
+        ----------
+        method:
+            Amplitude calculation method.
+        channel_index:
+            Index of the channel to aggregate.
+        amplitude_func:
+            Function returning ``(avg, err)`` for a dataset.
+
+        Returns
+        -------
+        tuple[list[float], list[float]]
+            Averaged amplitudes and standard errors for each stimulus bin.
+        """
+        bins: dict[float, list[float]] = {v: [] for v in self.stimulus_voltages}
+        for ds in self.datasets:
+            binned_voltages = np.round(np.array(ds.stimulus_voltages) / self.bin_size) * self.bin_size
+            amps, _ = amplitude_func(ds)
+            for v, amp in zip(binned_voltages, amps):
+                bins[v].append(amp)
+
+        avg = [float(np.mean(bins[v])) for v in self.stimulus_voltages]
+        sem = [float(np.std(bins[v]) / np.sqrt(len(bins[v]))) if bins[v] else 0.0
+               for v in self.stimulus_voltages]
+        return avg, sem
+
     def get_avg_m_wave_amplitudes(self, method: str, channel_index: int):
         return self._aggregate_wave_amplitudes(
             method=method,

--- a/monstim_signals/plotting/experiment_plotter.py
+++ b/monstim_signals/plotting/experiment_plotter.py
@@ -14,11 +14,13 @@ class EMGExperimentPlotter(BasePlotter):
         from monstim_signals.domain.experiment import Experiment
         if not isinstance(experiment, Experiment):
             raise TypeError("The provided object is not an instance of the Experiment class.")
-        self.emg_object : 'Experiment' = experiment # The EMGExperiment object to be imported.
+        # Store the experiment to plot.  BasePlotter uses ``emg_object`` as the
+        # generic data container attribute.
+        self.emg_object: 'Experiment' = experiment
         super().__init__(self.emg_object)
         self.set_plot_defaults()
 
-    # EMGExperiment plotting functions
+    # Experiment plotting functions
     def plot_reflexCurves(self, channel_indices : List[int] = None, method=None, plot_legend=True, relative_to_mmax=False, manual_mmax=None, canvas=None):
         """
         Plots the M-response and H-reflex curves for each channel.


### PR DESCRIPTION
## Summary
- implement `_aggregate_wave_amplitudes` helper in `Experiment`
- clarify comments in `experiment_plotter` and keep working with new `Experiment`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431104e6d4832594051a40b774c3a5