### PR TITLE
Improve test helpers

### DIFF
--- a/monstim_signals/domain/experiment.py
+++ b/monstim_signals/domain/experiment.py
@@ -143,7 +143,10 @@ class Experiment:
             for volt, amp in zip(binned, avg_vals):
                 wave_bins[volt].append(amp)
         avg = [np.mean(wave_bins[v]) for v in self.stimulus_voltages]
-        sem = [np.std(wave_bins[v]) / np.sqrt(len(wave_bins[v])) for v in self.stimulus_voltages]
+        sem = [
+            np.std(wave_bins[v]) / np.sqrt(len(wave_bins[v])) if len(wave_bins[v]) > 0 else None
+            for v in self.stimulus_voltages
+        ]
         return avg, sem
 
     def get_m_wave_amplitude_avgs_at_voltage(self, method: str, channel_index: int, voltage: float) -> List[float]:

--- a/monstim_signals/domain/experiment.py
+++ b/monstim_signals/domain/experiment.py
@@ -134,6 +134,18 @@ class Experiment:
             amplitude_func=lambda ds: ds.get_avg_m_wave_amplitudes(method, channel_index)
         )
 
+    def _aggregate_wave_amplitudes(self, method: str, channel_index: int, amplitude_func):
+        """Aggregate wave amplitudes across datasets."""
+        wave_bins = {v: [] for v in self.stimulus_voltages}
+        for ds in self.datasets:
+            binned = np.round(np.array(ds.stimulus_voltages) / self.bin_size) * self.bin_size
+            avg_vals, _ = amplitude_func(ds)
+            for volt, amp in zip(binned, avg_vals):
+                wave_bins[volt].append(amp)
+        avg = [np.mean(wave_bins[v]) for v in self.stimulus_voltages]
+        sem = [np.std(wave_bins[v]) / np.sqrt(len(wave_bins[v])) for v in self.stimulus_voltages]
+        return avg, sem
+
     def get_m_wave_amplitude_avgs_at_voltage(self, method: str, channel_index: int, voltage: float) -> List[float]:
         amps = []
         for ds in self.datasets:


### PR DESCRIPTION
## Summary
- add new dataset and experiment test helpers
- enhance session test coverage
- support aggregated wave amplitude calculations for experiments

## Testing
- `python - <<'EOF'
from monstim_signals.testing import test_session_object, test_dataset_object, test_experiment_object
print('session'); test_session_object(); print('dataset'); test_dataset_object(); print('experiment'); test_experiment_object(); print('done')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684311bce9188325af8a9b2b801b117f