### PR TITLE
Fix m-max averaging

### DIFF
--- a/monstim_signals/plotting/base_plotter.py
+++ b/monstim_signals/plotting/base_plotter.py
@@ -91,6 +91,21 @@ class BasePlotter:
             # plt.subplots_adjust(**self.emg_object.subplot_adjust_args)
             plt.show()
 
+    def _set_y_axis_limits(self, ax, values, fallback=1.0):
+        """Set a reasonable y-axis limit based on ``values``."""
+        import numpy as np
+
+        if len(values) == 0:
+            y_max = fallback
+        else:
+            try:
+                y_max = np.nanmax(values)
+            except ValueError:
+                y_max = fallback
+            if np.isnan(y_max) or y_max <= 0:
+                y_max = fallback
+        ax.set_ylim(0, 1.1 * y_max)
+
 class UnableToPlotError(Exception):
     def __init__(self, message):
         self.message = message

--- a/monstim_signals/plotting/base_plotter.py
+++ b/monstim_signals/plotting/base_plotter.py
@@ -93,7 +93,6 @@ class BasePlotter:
 
     def _set_y_axis_limits(self, ax, values, fallback=1.0):
         """Set a reasonable y-axis limit based on ``values``."""
-        import numpy as np
 
         if len(values) == 0:
             y_max = fallback

--- a/monstim_signals/plotting/dataset_plotter.py
+++ b/monstim_signals/plotting/dataset_plotter.py
@@ -254,12 +254,44 @@ class DatasetPlotter(BasePlotter):
             h_x = 2.5
             if num_channels == 1:
                 ax.plot(m_x, [m_wave_amplitudes], color=self.emg_object.m_color, marker='o', markersize=5)
-                ax.annotate(f'n={len(m_wave_amplitudes)}\navg. = {np.average(m_wave_amplitudes):.2f}\nstd. = {np.std(m_wave_amplitudes):.2f}', xy=(m_x + 0.4, np.mean(m_wave_amplitudes)), ha='left', color=self.emg_object.m_color)
-                ax.errorbar(m_x, np.mean(m_wave_amplitudes), yerr=np.std(m_wave_amplitudes), color='black', marker='+', markersize=10, capsize=10)
-                
+                mean_m = np.mean(m_wave_amplitudes) if m_wave_amplitudes else np.nan
+                std_m = np.std(m_wave_amplitudes) if m_wave_amplitudes else np.nan
+                ax.annotate(
+                    f'n={len(m_wave_amplitudes)}\navg. = {mean_m:.2f}\nstd. = {std_m:.2f}',
+                    xy=(m_x + 0.4, mean_m),
+                    ha='left',
+                    color=self.emg_object.m_color,
+                )
+                if m_wave_amplitudes:
+                    ax.errorbar(
+                        m_x,
+                        mean_m,
+                        yerr=std_m,
+                        color='black',
+                        marker='+',
+                        markersize=10,
+                        capsize=10,
+                    )
+
                 ax.plot(h_x, [h_response_amplitudes], color=self.emg_object.h_color, marker='o', markersize=5)
-                ax.annotate(f'n={len(h_response_amplitudes)}\navg. = {np.average(h_response_amplitudes):.2f}\nstd. = {np.std(h_response_amplitudes):.2f}', xy=(h_x + 0.4, np.mean(h_response_amplitudes)), ha='left', color=self.emg_object.h_color)
-                ax.errorbar(h_x, np.mean(h_response_amplitudes), yerr=np.std(h_response_amplitudes), color='black', marker='+', markersize=10, capsize=10)
+                mean_h = np.mean(h_response_amplitudes) if h_response_amplitudes else np.nan
+                std_h = np.std(h_response_amplitudes) if h_response_amplitudes else np.nan
+                ax.annotate(
+                    f'n={len(h_response_amplitudes)}\navg. = {mean_h:.2f}\nstd. = {std_h:.2f}',
+                    xy=(h_x + 0.4, mean_h),
+                    ha='left',
+                    color=self.emg_object.h_color,
+                )
+                if h_response_amplitudes:
+                    ax.errorbar(
+                        h_x,
+                        mean_h,
+                        yerr=std_h,
+                        color='black',
+                        marker='+',
+                        markersize=10,
+                        capsize=10,
+                    )
                 
                 ax.set_xticks([m_x, h_x])
                 ax.set_xticklabels(['M-response', 'H-reflex'])
@@ -267,12 +299,44 @@ class DatasetPlotter(BasePlotter):
                 ax.set_xlim(m_x-1, h_x+1) # Set x-axis limits for each subplot to better center data points.
             else:
                 axes[channel_index].plot(m_x, [m_wave_amplitudes], color=self.emg_object.m_color, marker='o', markersize=5)
-                axes[channel_index].annotate(f'n={len(m_wave_amplitudes)}\navg. = {np.average(m_wave_amplitudes):.2f}\nstd. = {np.std(m_wave_amplitudes):.2f}', xy=(m_x + 0.4, np.mean(m_wave_amplitudes)), ha='left', color=self.emg_object.m_color)
-                axes[channel_index].errorbar(m_x, np.mean(m_wave_amplitudes), yerr=np.std(m_wave_amplitudes), color='black', marker='+', markersize=10, capsize=10)
+                mean_m = np.mean(m_wave_amplitudes) if m_wave_amplitudes else np.nan
+                std_m = np.std(m_wave_amplitudes) if m_wave_amplitudes else np.nan
+                axes[channel_index].annotate(
+                    f'n={len(m_wave_amplitudes)}\navg. = {mean_m:.2f}\nstd. = {std_m:.2f}',
+                    xy=(m_x + 0.4, mean_m),
+                    ha='left',
+                    color=self.emg_object.m_color,
+                )
+                if m_wave_amplitudes:
+                    axes[channel_index].errorbar(
+                        m_x,
+                        mean_m,
+                        yerr=std_m,
+                        color='black',
+                        marker='+',
+                        markersize=10,
+                        capsize=10,
+                    )
 
                 axes[channel_index].plot(h_x, [h_response_amplitudes], color=self.emg_object.h_color, marker='o', markersize=5)
-                axes[channel_index].annotate(f'n={len(h_response_amplitudes)}\navg. = {np.average(h_response_amplitudes):.2f}\nstd. = {np.std(h_response_amplitudes):.2f}', xy=(h_x + 0.4, np.mean(h_response_amplitudes)), ha='left', color=self.emg_object.h_color)
-                axes[channel_index].errorbar(h_x, np.mean(h_response_amplitudes), yerr=np.std(h_response_amplitudes), color='black', marker='+', markersize=10, capsize=10)
+                mean_h = np.mean(h_response_amplitudes) if h_response_amplitudes else np.nan
+                std_h = np.std(h_response_amplitudes) if h_response_amplitudes else np.nan
+                axes[channel_index].annotate(
+                    f'n={len(h_response_amplitudes)}\navg. = {mean_h:.2f}\nstd. = {std_h:.2f}',
+                    xy=(h_x + 0.4, mean_h),
+                    ha='left',
+                    color=self.emg_object.h_color,
+                )
+                if h_response_amplitudes:
+                    axes[channel_index].errorbar(
+                        h_x,
+                        mean_h,
+                        yerr=std_h,
+                        color='black',
+                        marker='+',
+                        markersize=10,
+                        capsize=10,
+                    )
                 
                 axes[channel_index].set_title(f'{channel_names[channel_index]} ({round(max_h_reflex_voltage, 2)} ± {round((self.emg_object.bin_size/2)+(self.emg_object.bin_size * bin_margin),2)}V)')
                 axes[channel_index].set_xticks([m_x, h_x])
@@ -340,33 +404,75 @@ class DatasetPlotter(BasePlotter):
             session_ids = []
             for session in self.emg_object.sessions:
                 try:
-                    m_max, mmax_low_stim, _ = session.get_m_max(method=method, channel_index=channel_index, return_mmax_stim_range=True)
-                    m_max_amplitudes.append(m_max)
-                    m_max_thresholds.append(mmax_low_stim)
-                    session_ids.append(session.id)
-                except IndexError:
-                    m_max_amplitudes.append(np.nan)
-                    m_max_thresholds.append(np.nan)
-                    session_ids.append(session.id)
+                    m_max, mmax_low_stim, _ = session.get_m_max(
+                        method=method,
+                        channel_index=channel_index,
+                        return_mmax_stim_range=True,
+                    )
+                except Exception:
+                    m_max = np.nan
+                    mmax_low_stim = np.nan
+                m_max_amplitudes.append(m_max)
+                m_max_thresholds.append(mmax_low_stim)
+                session_ids.append(session.id)
                 
             # Append M-wave amplitudes to superlist for y-axis adjustment.
-            all_m_max_amplitudes.extend(m_max_amplitudes)            
+            all_m_max_amplitudes.extend(
+                [amp for amp in m_max_amplitudes if not np.isnan(amp)]
+            )
 
             # Plot the M-wave amplitudes for each session
             m_x = 1
+            valid_amplitudes = [amp for amp in m_max_amplitudes if not np.isnan(amp)]
+            valid_thresholds = [thr for thr in m_max_thresholds if not np.isnan(thr)]
+
+            mean_amp = np.mean(valid_amplitudes) if valid_amplitudes else np.nan
+            std_amp = np.std(valid_amplitudes) if valid_amplitudes else np.nan
+            mean_thresh = np.mean(valid_thresholds) if valid_thresholds else np.nan
+
             if num_channels == 1:
-                ax.plot(m_x, [m_max_amplitudes], color=self.emg_object.m_color, marker='o', markersize=5)
-                ax.annotate(f'n={len(m_max_amplitudes)}\nAvg. M-max: {np.mean(m_max_amplitudes):.2f}mV\nStdev. M-Max: {np.std(m_max_amplitudes):.2f}mV\nAvg. Stim.: above {np.mean(m_max_thresholds):.2f} mV', xy=(m_x + 0.2, np.mean(m_max_amplitudes)), ha='left', va='center', color='black')
-                ax.errorbar(m_x, np.mean(m_max_amplitudes), yerr=np.std(m_max_amplitudes), color='black', marker='+', markersize=10, capsize=10)
+                ax.plot(m_x, [valid_amplitudes], color=self.emg_object.m_color, marker='o', markersize=5)
+                ax.annotate(
+                    f'n={len(valid_amplitudes)}\nAvg. M-max: {mean_amp:.2f}mV\nStdev. M-Max: {std_amp:.2f}mV\nAvg. Stim.: above {mean_thresh:.2f} mV',
+                    xy=(m_x + 0.2, mean_amp),
+                    ha='left',
+                    va='center',
+                    color='black',
+                )
+                if valid_amplitudes:
+                    ax.errorbar(
+                        m_x,
+                        mean_amp,
+                        yerr=std_amp,
+                        color='black',
+                        marker='+',
+                        markersize=10,
+                        capsize=10,
+                    )
                 
                 ax.set_xticklabels(['M-response'])
                 ax.set_title(f'{channel_names[0]}')                    
                 ax.set_xlim(m_x-1, m_x+1.5)  # Center data points
                 self._set_y_axis_limits(ax, all_m_max_amplitudes)
             else:
-                axes[channel_index].plot(m_x, [m_max_amplitudes], color=self.emg_object.m_color, marker='o', markersize=5)
-                axes[channel_index].annotate(f'n={len(m_max_amplitudes)}\nAvg. M-max: {np.mean(m_max_amplitudes):.2f}mV\nStdev. M-Max: {np.std(m_max_amplitudes):.2f}mV\nAvg. Stim.: above {np.mean(m_max_thresholds):.2f} mV', xy=(m_x + 0.2, np.mean(m_max_amplitudes)), ha='left', va='center', color='black')
-                axes[channel_index].errorbar(m_x, np.mean(m_max_amplitudes), yerr=np.std(m_max_amplitudes), color='black', marker='+', markersize=10, capsize=10)
+                axes[channel_index].plot(m_x, [valid_amplitudes], color=self.emg_object.m_color, marker='o', markersize=5)
+                axes[channel_index].annotate(
+                    f'n={len(valid_amplitudes)}\nAvg. M-max: {mean_amp:.2f}mV\nStdev. M-Max: {std_amp:.2f}mV\nAvg. Stim.: above {mean_thresh:.2f} mV',
+                    xy=(m_x + 0.2, mean_amp),
+                    ha='left',
+                    va='center',
+                    color='black',
+                )
+                if valid_amplitudes:
+                    axes[channel_index].errorbar(
+                        m_x,
+                        mean_amp,
+                        yerr=std_amp,
+                        color='black',
+                        marker='+',
+                        markersize=10,
+                        capsize=10,
+                    )
                 
                 axes[channel_index].set_xticks([m_x])
                 axes[channel_index].set_xticklabels(['M-response'])


### PR DESCRIPTION
## Summary
- fix M-max averaging with missing values in `Dataset` and `Experiment`
- handle invalid M-max results gracefully in dataset/experiment plotting
- guard all amplitude averaging against empty lists and add y-axis util

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431e98e24883258e8235180e5262a2