### PR TITLE
Improve DataSelectionWidget visuals

### DIFF
--- a/monstim_gui/data_selection_widget.py
+++ b/monstim_gui/data_selection_widget.py
@@ -37,7 +37,7 @@ class CircleDelegate(QStyledItemDelegate):
         """Draw the item text and a completion circle."""
         # Reserve space on the right for the status circle
         option_no_circle = QStyleOptionViewItem(option)
-        option_no_circle.rect = option.rect.adjusted(0, 0, -20, 0)
+        option_no_circle.rect = option.rect.adjusted(0, 0, -self.CIRCLE_PADDING, 0)
 
         super().paint(painter, option_no_circle, index)
 

--- a/monstim_gui/data_selection_widget.py
+++ b/monstim_gui/data_selection_widget.py
@@ -77,7 +77,11 @@ class DataSelectionWidget(QGroupBox):
         for combo in (self.dataset_combo, self.session_combo):
             combo.setItemDelegate(self.circle_delegate)
             combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
-            combo.setTextElideMode(Qt.TextElideMode.Right)
+            # Qt <6.5 lacks QComboBox.setTextElideMode; fallback to the view
+            try:
+                combo.setTextElideMode(Qt.TextElideMode.ElideRight)
+            except AttributeError:
+                combo.view().setTextElideMode(Qt.TextElideMode.ElideRight)
 
     def setup_context_menus(self):
         for combo in (self.experiment_combo, self.dataset_combo, self.session_combo):

--- a/monstim_gui/data_selection_widget.py
+++ b/monstim_gui/data_selection_widget.py
@@ -1,6 +1,15 @@
 import logging
 from typing import TYPE_CHECKING
-from PyQt6.QtWidgets import QGroupBox, QVBoxLayout, QHBoxLayout, QLabel, QComboBox, QMenu, QStyledItemDelegate
+from PyQt6.QtWidgets import (
+    QGroupBox,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QComboBox,
+    QMenu,
+    QStyledItemDelegate,
+    QStyleOptionViewItem,
+)
 from PyQt6.QtCore import Qt, QRect
 from PyQt6.QtGui import QColor, QPainter
 
@@ -25,16 +34,21 @@ class CircleDelegate(QStyledItemDelegate):
         self.uncompleted_color = QColor(255, 0, 0)  # Red
         
     def paint(self, painter: QPainter, option, index):
-        super().paint(painter, option, index)
-        
+        """Draw the item text and a completion circle."""
+        # Reserve space on the right for the status circle
+        option_no_circle = QStyleOptionViewItem(option)
+        option_no_circle.rect = option.rect.adjusted(0, 0, -20, 0)
+
+        super().paint(painter, option_no_circle, index)
+
         # Get completion status from item data
         is_completed = index.data(Qt.ItemDataRole.UserRole)
-        
-        # Draw circle
-        circle_rect = QRect(option.rect.right() - 20, 
-                          option.rect.center().y() - 6,
-                          12, 12)
-        
+
+        # Draw circle indicating completion
+        circle_rect = QRect(option.rect.right() - 18,
+                            option.rect.center().y() - 6,
+                            12, 12)
+
         painter.save()
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
         color = self.completed_color if is_completed else self.uncompleted_color
@@ -51,6 +65,7 @@ class DataSelectionWidget(QGroupBox):
         
         self.layout = QVBoxLayout(self)
         self.layout.setSpacing(5)
+        self.layout.setContentsMargins(5, 5, 5, 5)
         self.create_experiment_selection()
         self.create_dataset_selection()
         self.create_session_selection()
@@ -61,6 +76,8 @@ class DataSelectionWidget(QGroupBox):
         # Apply delegate to all combos
         for combo in (self.dataset_combo, self.session_combo):
             combo.setItemDelegate(self.circle_delegate)
+            combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
+            combo.setTextElideMode(Qt.TextElideMode.Right)
 
     def setup_context_menus(self):
         for combo in (self.experiment_combo, self.dataset_combo, self.session_combo):


### PR DESCRIPTION
## Summary
- adjust DataSelectionWidget layout margins
- prevent completion circle from overlapping text
- allow combos to expand and elide overflowed text

## Testing
- `python -m py_compile monstim_gui/data_selection_widget.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846eb8fb1748325a6b60982a5cf6298