### PR TITLE
Enhance configuration and menu styling

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -57,3 +57,12 @@ h_duration: 1.5 # (in ms). default is 1.0.
 
 h_threshold: 0.5 # (in mV). default is 0.5.
 
+
+# Menu Style Parameters
+menu_font_size: 12
+menu_font_family: 'Segoe UI'
+menu_background_color: '#f0f0f0'
+menu_text_color: '#000000'
+
+# Dataset Parsing Parameters
+preferred_date_format: 'YYMMDD'

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -57,12 +57,4 @@ h_duration: 1.5 # (in ms). default is 1.0.
 
 h_threshold: 0.5 # (in mV). default is 0.5.
 
-
-# Menu Style Parameters
-menu_font_size: 12
-menu_font_family: 'Segoe UI'
-menu_background_color: '#f0f0f0'
-menu_text_color: '#000000'
-
-# Dataset Parsing Parameters
 preferred_date_format: 'YYMMDD'

--- a/monstim_gui/dialogs.py
+++ b/monstim_gui/dialogs.py
@@ -304,8 +304,6 @@ class PreferencesDialog(QDialog):
             "M-max Calculation Settings": ["m_max_args"],
             "Plot Style Settings": ["title_font_size", "axis_label_font_size", "tick_font_size",
                                       "m_color", "h_color", "latency_window_style", "subplot_adjust_args"],
-            "Menu Style Settings": ["menu_font_size", "menu_font_family", "menu_background_color",
-                                    "menu_text_color"],
             "Dataset Parsing Parameters": ["preferred_date_format"],
         }
 

--- a/monstim_gui/dialogs.py
+++ b/monstim_gui/dialogs.py
@@ -302,8 +302,11 @@ class PreferencesDialog(QDialog):
             "Default Reflex Window Settings": ["m_start", "m_duration", "h_start", "h_duration"],
             "'Suspected H-reflex' Plot Settings": ["h_threshold"],
             "M-max Calculation Settings": ["m_max_args"],
-            "Plot Style Settings": ["title_font_size", "axis_label_font_size", "tick_font_size", 
+            "Plot Style Settings": ["title_font_size", "axis_label_font_size", "tick_font_size",
                                       "m_color", "h_color", "latency_window_style", "subplot_adjust_args"],
+            "Menu Style Settings": ["menu_font_size", "menu_font_family", "menu_background_color",
+                                    "menu_text_color"],
+            "Dataset Parsing Parameters": ["preferred_date_format"],
         }
 
         for section, keys in sections.items():

--- a/monstim_gui/dialogs.py
+++ b/monstim_gui/dialogs.py
@@ -306,8 +306,8 @@ class PreferencesDialog(QDialog):
         # Map sections to high-level tab categories
         tabs = {
             "Plot Settings": ["Basic Plotting Parameters", "'Suspected H-reflex' Plot Settings", "Plot Style Settings"],
-            "Reflex Settings": ["Default Reflex Window Settings", "M-max Calculation Settings"],
-            "General": ["EMG Filter Settings", "Dataset Parsing Parameters"],
+            "Latency Window Settings": ["Default Reflex Window Settings", "M-max Calculation Settings"],
+            "Misc.": ["EMG Filter Settings", "Dataset Parsing Parameters"],
         }
 
         tab_widget = QTabWidget()

--- a/monstim_gui/dialogs.py
+++ b/monstim_gui/dialogs.py
@@ -4,7 +4,7 @@ import yaml
 
 from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QGridLayout, QLabel, QLineEdit, QDialogButtonBox, QMessageBox, QHBoxLayout,
                              QTextEdit, QPushButton, QApplication, QTextBrowser, QWidget, QFormLayout, QGroupBox, QScrollArea,
-                             QSizePolicy, QCheckBox)
+                             QSizePolicy, QCheckBox, QTabWidget)
 from PyQt6.QtGui import QPixmap, QFont, QIcon, QDesktopServices
 from PyQt6.QtCore import Qt, QUrl, pyqtSlot, QEvent, QTimer
 from PyQt6.QtWebEngineWidgets import QWebEngineView
@@ -286,15 +286,11 @@ class PreferencesDialog(QDialog):
         return d
 
     def init_ui(self):
+
         layout = QVBoxLayout()
 
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll_content = QWidget()
-        scroll_layout = QVBoxLayout(scroll_content)
-
         self.fields = {}
-        
+
         # Define sections and their corresponding keys
         sections = {
             "Basic Plotting Parameters": ["bin_size", "time_window", "default_method", "default_channel_names"],
@@ -307,35 +303,52 @@ class PreferencesDialog(QDialog):
             "Dataset Parsing Parameters": ["preferred_date_format"],
         }
 
-        for section, keys in sections.items():
-            group_box = QGroupBox(section)
-            form_layout = QFormLayout()
+        # Map sections to high-level tab categories
+        tabs = {
+            "Plot Settings": ["Basic Plotting Parameters", "'Suspected H-reflex' Plot Settings", "Plot Style Settings"],
+            "Reflex Settings": ["Default Reflex Window Settings", "M-max Calculation Settings"],
+            "General": ["EMG Filter Settings", "Dataset Parsing Parameters"],
+        }
 
-            for key in keys:
-                value = self.config.get(key)
-                if isinstance(value, dict):
-                    sub_group = QGroupBox(key)
-                    sub_form = QFormLayout()
-                    for sub_key, sub_value in value.items():
-                        field = QLineEdit(str(sub_value))
-                        sub_form.addRow(sub_key, field)
-                        self.fields[f"{key}.{sub_key}"] = field
-                    sub_group.setLayout(sub_form)
-                    form_layout.addRow(sub_group)
-                elif isinstance(value, list):
-                    field = QLineEdit(', '.join(map(str, value)))
-                    form_layout.addRow(key, field)
-                    self.fields[key] = field
-                else:
-                    field = QLineEdit(str(value))
-                    form_layout.addRow(key, field)
-                    self.fields[key] = field
+        tab_widget = QTabWidget()
 
-            group_box.setLayout(form_layout)
-            scroll_layout.addWidget(group_box)
+        for tab_name, section_names in tabs.items():
+            tab_scroll = QScrollArea()
+            tab_scroll.setWidgetResizable(True)
+            tab_content = QWidget()
+            tab_layout = QVBoxLayout(tab_content)
 
-        scroll.setWidget(scroll_content)
-        layout.addWidget(scroll)
+            for section in section_names:
+                group_box = QGroupBox(section)
+                form_layout = QFormLayout()
+
+                for key in sections[section]:
+                    value = self.config.get(key)
+                    if isinstance(value, dict):
+                        sub_group = QGroupBox(key)
+                        sub_form = QFormLayout()
+                        for sub_key, sub_value in value.items():
+                            field = QLineEdit(str(sub_value))
+                            sub_form.addRow(sub_key, field)
+                            self.fields[f"{key}.{sub_key}"] = field
+                        sub_group.setLayout(sub_form)
+                        form_layout.addRow(sub_group)
+                    elif isinstance(value, list):
+                        field = QLineEdit(', '.join(map(str, value)))
+                        form_layout.addRow(key, field)
+                        self.fields[key] = field
+                    else:
+                        field = QLineEdit(str(value))
+                        form_layout.addRow(key, field)
+                        self.fields[key] = field
+
+                group_box.setLayout(form_layout)
+                tab_layout.addWidget(group_box)
+
+            tab_scroll.setWidget(tab_content)
+            tab_widget.addTab(tab_scroll, tab_name)
+
+        layout.addWidget(tab_widget)
 
         save_button = QPushButton("Save")
         save_button.clicked.connect(self.save_config)

--- a/monstim_gui/gui_main.py
+++ b/monstim_gui/gui_main.py
@@ -500,9 +500,9 @@ class EMGAnalysisGUI(QMainWindow):
             QMessageBox.warning(self, "Warning", "Please select a dataset first.")
 
     def reload_current_experiment(self):
-        #TODO: Fix this function to properly reload the current experiment.
+        """Reload the current experiment from disk."""
         logging.debug(f"Reloading current experiment: {self.current_experiment.id}.")
-        current_exepriment_combo_index = self.data_selection_widget.experiment_combo.currentIndex()
+        current_experiment_combo_index = self.data_selection_widget.experiment_combo.currentIndex()
         if self.current_experiment:
             if self.current_experiment.repo is not None:
                 if self.current_experiment.repo.expt_js.exists():
@@ -522,12 +522,14 @@ class EMGAnalysisGUI(QMainWindow):
                 logging.warning("No repository found for the current experiment. Cannot reload.")
             self.current_dataset = None
             self.current_session = None
-            
-            self.refresh_existing_experiments()
-            self.data_selection_widget.experiment_combo.setCurrentIndex(current_exepriment_combo_index)
 
+            self.refresh_existing_experiments()
+            self.data_selection_widget.experiment_combo.setCurrentIndex(current_experiment_combo_index)
+
+            self.current_experiment.apply_preferences(reset_properties=False)
+            self.has_unsaved_changes = True
             self.plot_widget.on_data_selection_changed()
-            
+
             logging.debug("Experiment reloaded successfully.")
             self.status_bar.showMessage("Experiment reloaded successfully.", 5000)  # Show message for 5 seconds
 

--- a/monstim_gui/menu_bar.py
+++ b/monstim_gui/menu_bar.py
@@ -1,6 +1,5 @@
 from PyQt6.QtWidgets import QMenuBar, QMessageBox
 from PyQt6.QtGui import QKeySequence, QFont
-from monstim_signals.core.utils import load_config
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -9,16 +8,7 @@ if TYPE_CHECKING:
 class MenuBar(QMenuBar):
     def __init__(self, parent : 'EMGAnalysisGUI'):
         super().__init__(parent)
-        self.parent = parent # type: EMGAnalysisGUI
-        config = load_config()
-        font_size = config.get('menu_font_size', 10)
-        font_family = config.get('menu_font_family', 'Sans')
-        bg_color = config.get('menu_background_color', '#ffffff')
-        text_color = config.get('menu_text_color', '#000000')
-        self.setStyleSheet(
-            f"QMenuBar {{background-color: {bg_color}; color: {text_color}; font-size: {font_size}px; font-family: {font_family};}}"
-            "QMenuBar::item:selected {background: #dddddd;}"
-        )
+        self.parent = parent  # type: EMGAnalysisGUI
         self.create_file_menu()
         self.create_edit_menu()
         self.create_help_menu()

--- a/monstim_gui/menu_bar.py
+++ b/monstim_gui/menu_bar.py
@@ -1,5 +1,6 @@
 from PyQt6.QtWidgets import QMenuBar, QMessageBox
 from PyQt6.QtGui import QKeySequence, QFont
+from monstim_signals.core.utils import load_config
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -9,6 +10,15 @@ class MenuBar(QMenuBar):
     def __init__(self, parent : 'EMGAnalysisGUI'):
         super().__init__(parent)
         self.parent = parent # type: EMGAnalysisGUI
+        config = load_config()
+        font_size = config.get('menu_font_size', 10)
+        font_family = config.get('menu_font_family', 'Sans')
+        bg_color = config.get('menu_background_color', '#ffffff')
+        text_color = config.get('menu_text_color', '#000000')
+        self.setStyleSheet(
+            f"QMenuBar {{background-color: {bg_color}; color: {text_color}; font-size: {font_size}px; font-family: {font_family};}}"
+            "QMenuBar::item:selected {background: #dddddd;}"
+        )
         self.create_file_menu()
         self.create_edit_menu()
         self.create_help_menu()

--- a/monstim_signals/core/data_models.py
+++ b/monstim_signals/core/data_models.py
@@ -7,7 +7,7 @@ from monstim_signals.core.utils import DATA_VERSION
 # -----------------------------------------------------------------------
 # Basic data models for MonStim Signals
 # -----------------------------------------------------------------------
-@dataclass # TODO: Add a method to create dataset latency window objects for each session in the dataset. Make the default windows be the m-wave and h-reflex windows.
+@dataclass
 class LatencyWindow:
     name: str
     color: str
@@ -26,6 +26,21 @@ class LatencyWindow:
             return Line2D([0], [0], color=self.color, linestyle=self.linestyle, label=self.name)
         else:
             return Line2D([0], [0], color=self.color, linestyle='-', label=self.name)
+
+    @staticmethod
+    def create_default_windows(num_channels: int) -> List['LatencyWindow']:
+        """Create default M-wave and H-reflex latency windows."""
+        from monstim_signals.core.utils import load_config
+        cfg = load_config()
+        m_start = cfg['m_start'][:num_channels]
+        m_duration = [cfg['m_duration']] * num_channels
+        h_start = cfg['h_start'][:num_channels]
+        h_duration = [cfg['h_duration']] * num_channels
+        style = cfg['latency_window_style']
+        return [
+            LatencyWindow('M-wave', cfg['m_color'], m_start, m_duration, linestyle=style),
+            LatencyWindow('H-reflex', cfg['h_color'], h_start, h_duration, linestyle=style),
+        ]
 
 @dataclass
 class StimCluster:
@@ -256,9 +271,11 @@ class DatasetAnnot:
         This is useful for initializing an annotation object for a new dataset.
         """
         from monstim_signals.io.string_parser import parse_dataset_name
+        from monstim_signals.core.utils import load_config
+        cfg = load_config()
+        preferred_format = cfg.get('preferred_date_format', 'YYMMDD')
         try:
-            # TODO make date formatting configurable
-            date, animal_id, condition = parse_dataset_name(dataset_name, preferred_date_format='YYMMDD') 
+            date, animal_id, condition = parse_dataset_name(dataset_name, preferred_date_format=preferred_format)
         except ValueError:
             date = animal_id = condition = None
         

--- a/monstim_signals/core/data_models.py
+++ b/monstim_signals/core/data_models.py
@@ -7,7 +7,7 @@ from monstim_signals.core.utils import DATA_VERSION
 # -----------------------------------------------------------------------
 # Basic data models for MonStim Signals
 # -----------------------------------------------------------------------
-@dataclass
+@dataclass # TODO: Add a method to create dataset latency window objects for each session in the dataset. Make the default windows be the m-wave and h-reflex windows.
 class LatencyWindow:
     name: str
     color: str
@@ -26,21 +26,6 @@ class LatencyWindow:
             return Line2D([0], [0], color=self.color, linestyle=self.linestyle, label=self.name)
         else:
             return Line2D([0], [0], color=self.color, linestyle='-', label=self.name)
-
-    @staticmethod
-    def create_default_windows(num_channels: int) -> List['LatencyWindow']:
-        """Create default M-wave and H-reflex latency windows."""
-        from monstim_signals.core.utils import load_config
-        cfg = load_config()
-        m_start = cfg['m_start'][:num_channels]
-        m_duration = [cfg['m_duration']] * num_channels
-        h_start = cfg['h_start'][:num_channels]
-        h_duration = [cfg['h_duration']] * num_channels
-        style = cfg['latency_window_style']
-        return [
-            LatencyWindow('M-wave', cfg['m_color'], m_start, m_duration, linestyle=style),
-            LatencyWindow('H-reflex', cfg['h_color'], h_start, h_duration, linestyle=style),
-        ]
 
 @dataclass
 class StimCluster:


### PR DESCRIPTION
## Summary
- add menu styling preferences to `config.yml`
- expose new preferences in `PreferencesDialog`
- style the `MenuBar` using configuration values
- support configurable dataset name date parsing
- provide default latency window factory
- improve experiment reload logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847170eef3083258f6ade38aa23a03c