### PR TITLE
General latency windows

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -65,7 +65,7 @@ MonStim EMG Analyzer is a graphical user interface (GUI) application designed to
         - Use "Undo"/"Redo" to undo/redo the removal/addition of sessions.
         - Alternatively use the "Edit" > "Reload Current Dataset" button to restore all sessions to the dataset. This will preserve any changes you made to the dataset such as channel names or reflex time windows.
     - Use "Edit" > "Change Channel Names" to modify channel labels.
-    - Use "Edit" > "Update Reflex Time Windows" to adjust latency window parameters (For now just M-wave and H-reflex windows).
+    - Use "Edit" > "Manage Latency Windows" to create, remove, or edit latency windows for EMG measurements. Each window can have channel specific start times while the duration stays the same. Changes can be undone with the Undo action.
     - Use "Edit" > "Invert Channel Polarity" to select any desired channels in the currently selected dataset for which you would like to invert the polarity. This will be applied to all sessions in the dataset for each of the selected channels.
     - To view/exclude individual recordings, use the Single Session plot type called "Single EMG Recordings". Cycle through the individual recordings and exclude/include any that you desire. Use "Edit" > "Reload Current Session" to reset all changes.
     - For advanced users, set user preferences in "File" > "Preferences".

--- a/monstim_gui/commands.py
+++ b/monstim_gui/commands.py
@@ -157,3 +157,55 @@ class InvertChannelPolarityCommand(Command):
     def undo(self):
         for channel_index in self.channel_indexes_to_invert:
             self.level.invert_channel_polarity(channel_index)
+
+class SetLatencyWindowsCommand(Command):
+    def __init__(self, gui, level: str, new_windows: list):
+        self.command_name = "Set Latency Windows"
+        self.gui = gui
+        import copy
+        match level:
+            case 'experiment':
+                self.level = self.gui.current_experiment
+                self.sessions = [s for ds in self.level.datasets for s in ds.sessions]
+            case 'dataset':
+                self.level = self.gui.current_dataset
+                self.sessions = list(self.level.sessions)
+            case 'session':
+                self.level = self.gui.current_session
+                self.sessions = [self.level]
+            case _:
+                raise ValueError(f"Invalid level: {level}")
+        self.new_windows = [copy.deepcopy(w) for w in new_windows]
+        self.old_windows = {s.id: copy.deepcopy(s.annot.latency_windows) for s in self.sessions}
+
+    def _apply(self, windows):
+        import copy
+        for s in self.sessions:
+            s.annot.latency_windows = [copy.deepcopy(w) for w in windows]
+            s.update_latency_window_parameters()
+            if s.repo is not None:
+                s.repo.save(s)
+        if hasattr(self.level, 'update_latency_window_parameters'):
+            if isinstance(self.level, list):
+                for obj in self.level:
+                    obj.update_latency_window_parameters()
+            else:
+                self.level.update_latency_window_parameters()
+
+    def execute(self):
+        self._apply(self.new_windows)
+
+    def undo(self):
+        for s in self.sessions:
+            windows = self.old_windows[s.id]
+            s.annot.latency_windows = windows
+            s.update_latency_window_parameters()
+            if s.repo is not None:
+                s.repo.save(s)
+        if hasattr(self.level, 'update_latency_window_parameters'):
+            if isinstance(self.level, list):
+                for obj in self.level:
+                    obj.update_latency_window_parameters()
+            else:
+                self.level.update_latency_window_parameters()
+

--- a/monstim_gui/dialogs.py
+++ b/monstim_gui/dialogs.py
@@ -40,9 +40,6 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib import colors as mcolors
 
-# Small set of pleasant colors for latency windows
-COLOR_OPTIONS = list(mcolors.TABLEAU_COLORS.keys())
-
 from monstim_signals.core.utils import get_source_path, CustomLoader
 from monstim_signals.domain.dataset import Dataset
 from monstim_signals.domain.session import Session
@@ -50,6 +47,9 @@ from monstim_signals.domain.experiment import Experiment
 from monstim_signals.core.data_models import LatencyWindow
 from monstim_gui.commands import SetLatencyWindowsCommand
 from monstim_gui.splash import SPLASH_INFO
+
+# Small set of pleasant colors for latency windows
+COLOR_OPTIONS = list(mcolors.TABLEAU_COLORS.keys())
 
 
 class WebEnginePage(QWebEnginePage):

--- a/monstim_gui/dialogs.py
+++ b/monstim_gui/dialogs.py
@@ -1,10 +1,30 @@
 import logging
 import os
 import yaml
+import copy
 
-from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QGridLayout, QLabel, QLineEdit, QDialogButtonBox, QMessageBox, QHBoxLayout,
-                             QTextEdit, QPushButton, QApplication, QTextBrowser, QWidget, QFormLayout, QGroupBox, QScrollArea,
-                             QSizePolicy, QCheckBox)
+from PyQt6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QGridLayout,
+    QLabel,
+    QLineEdit,
+    QDialogButtonBox,
+    QMessageBox,
+    QHBoxLayout,
+    QTextEdit,
+    QPushButton,
+    QApplication,
+    QTextBrowser,
+    QWidget,
+    QFormLayout,
+    QGroupBox,
+    QScrollArea,
+    QSizePolicy,
+    QCheckBox,
+    QComboBox,
+    QDoubleSpinBox,
+)
 from PyQt6.QtGui import QPixmap, QFont, QIcon, QDesktopServices
 from PyQt6.QtCore import Qt, QUrl, pyqtSlot, QEvent, QTimer
 from PyQt6.QtWebEngineWidgets import QWebEngineView
@@ -18,11 +38,14 @@ from mdx_math import MathExtension
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
+from matplotlib import colors as mcolors
 
 from monstim_signals.core.utils import get_source_path, CustomLoader
 from monstim_signals.domain.dataset import Dataset
 from monstim_signals.domain.session import Session
 from monstim_signals.domain.experiment import Experiment
+from monstim_signals.core.data_models import LatencyWindow
+from monstim_gui.commands import SetLatencyWindowsCommand
 from monstim_gui.splash import SPLASH_INFO
 
 
@@ -726,4 +749,150 @@ class SelectChannelsDialog(QDialog):
     def get_selected_channel_indexes(self):
         # Return the indexes of the channels where checkboxes are checked
         return [i for i, checkbox in enumerate(self.checkboxes) if checkbox.isChecked()]
+
+
+class WindowStartDialog(QDialog):
+    """Dialog for editing per-channel latency window start times."""
+
+    def __init__(self, window: LatencyWindow, channel_names: list[str], parent=None):
+        super().__init__(parent)
+        self.window = window
+        self.channel_names = channel_names
+        self.setModal(True)
+        self.setWindowTitle(f"Edit Start Times - {window.name}")
+        self.spin_boxes: list[QDoubleSpinBox] = []
+        self._init_ui()
+
+    def _init_ui(self):
+        layout = QVBoxLayout(self)
+        for name, start in zip(self.channel_names, self.window.start_times):
+            row = QHBoxLayout()
+            row.addWidget(QLabel(name))
+            spin = QDoubleSpinBox()
+            spin.setDecimals(2)
+            spin.setRange(-1000.0, 1000.0)
+            spin.setSingleStep(0.05)
+            spin.setValue(start)
+            row.addWidget(spin)
+            self.spin_boxes.append(spin)
+            layout.addLayout(row)
+
+        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel, self)
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+    def get_start_times(self) -> list[float]:
+        return [sb.value() for sb in self.spin_boxes]
+
+
+class LatencyWindowsDialog(QDialog):
+    """Dialog for editing multiple latency windows."""
+
+    COLOR_OPTIONS = list(mcolors.TABLEAU_COLORS.keys())
+
+    def __init__(self, data: Experiment | Dataset | Session, parent=None):
+        super().__init__(parent)
+        self.data = data
+        self.gui = parent  # EMGAnalysisGUI
+        self.setModal(True)
+        self.setWindowTitle("Manage Latency Windows")
+        self.window_entries = []  # type: list[tuple[QGroupBox, LatencyWindow, QLineEdit, QDoubleSpinBox, QDoubleSpinBox, QComboBox]]
+        self.init_ui()
+
+    def init_ui(self):
+        layout = QVBoxLayout(self)
+
+        self.scroll = QScrollArea()
+        self.scroll.setWidgetResizable(True)
+        self.scroll_widget = QWidget()
+        self.scroll_layout = QVBoxLayout(self.scroll_widget)
+        self.scroll.setWidget(self.scroll_widget)
+        layout.addWidget(self.scroll)
+
+        for window in self.data.latency_windows:
+            self._add_window_group(window)
+
+        add_button = QPushButton("Add Window")
+        add_button.clicked.connect(lambda: self._add_window_group())
+        layout.addWidget(add_button)
+
+        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel, self)
+        button_box.accepted.connect(self.save_windows)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+    def _add_window_group(self, window: LatencyWindow | None = None):
+        num_channels = len(self.data.channel_names)
+        if window is None:
+            window = LatencyWindow(
+                name=f"Window {len(self.window_entries)+1}",
+                start_times=[0.0] * num_channels,
+                durations=[1.0] * num_channels,
+                color="black",
+                linestyle=":"
+            )
+        group = QGroupBox(window.name)
+        form = QFormLayout()
+        name_edit = QLineEdit(window.name)
+        start_spin = QDoubleSpinBox()
+        start_spin.setDecimals(2)
+        start_spin.setRange(-1000.0, 1000.0)
+        start_spin.setSingleStep(0.05)
+        start_spin.setValue(window.start_times[0])
+        dur_spin = QDoubleSpinBox()
+        dur_spin.setDecimals(2)
+        dur_spin.setRange(0.0, 1000.0)
+        dur_spin.setSingleStep(0.05)
+        dur_spin.setValue(window.durations[0])
+        color_combo = QComboBox()
+        color_combo.addItems(self.COLOR_OPTIONS)
+        if window.color in self.COLOR_OPTIONS:
+            color_combo.setCurrentText(window.color)
+        remove_btn = QPushButton("Remove")
+        remove_btn.clicked.connect(lambda: self._remove_window_group(group))
+        edit_btn = QPushButton("Edit Starts...")
+        edit_btn.clicked.connect(lambda: self._edit_window_starts(window, start_spin))
+        form.addRow("Name", name_edit)
+        form.addRow("Start (Ch 0)", start_spin)
+        form.addRow("Duration", dur_spin)
+        form.addRow("Color", color_combo)
+        form.addRow(remove_btn, edit_btn)
+        group.setLayout(form)
+        self.scroll_layout.addWidget(group)
+        self.window_entries.append((group, window, name_edit, start_spin, dur_spin, color_combo))
+
+    def _remove_window_group(self, group: QGroupBox):
+        for i, (grp, *_ ) in enumerate(self.window_entries):
+            if grp is group:
+                self.window_entries.pop(i)
+                break
+        group.setParent(None)
+
+    def _edit_window_starts(self, window: LatencyWindow, start_spin: QDoubleSpinBox):
+        dialog = WindowStartDialog(window, self.data.channel_names, self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            window.start_times = dialog.get_start_times()
+            start_spin.setValue(window.start_times[0])
+
+    def save_windows(self):
+        new_windows = []
+        num_channels = len(self.data.channel_names)
+        for group, window, name_edit, start_spin, dur_spin, color_combo in self.window_entries:
+            window.name = name_edit.text().strip() or "Window"
+            window.start_times[0] = start_spin.value()
+            window.durations = [dur_spin.value()] * num_channels
+            window.color = color_combo.currentText()
+            new_windows.append(copy.deepcopy(window))
+
+        if isinstance(self.data, Experiment):
+            level = 'experiment'
+        elif isinstance(self.data, Dataset):
+            level = 'dataset'
+        else:
+            level = 'session'
+
+        command = SetLatencyWindowsCommand(self.gui, level, new_windows)
+        self.gui.command_invoker.execute(command)
+        self.accept()
         

--- a/monstim_gui/dialogs.py
+++ b/monstim_gui/dialogs.py
@@ -40,6 +40,9 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib import colors as mcolors
 
+# Small set of pleasant colors for latency windows
+COLOR_OPTIONS = list(mcolors.TABLEAU_COLORS.keys())
+
 from monstim_signals.core.utils import get_source_path, CustomLoader
 from monstim_signals.domain.dataset import Dataset
 from monstim_signals.domain.session import Session
@@ -789,8 +792,6 @@ class WindowStartDialog(QDialog):
 class LatencyWindowsDialog(QDialog):
     """Dialog for editing multiple latency windows."""
 
-    COLOR_OPTIONS = list(mcolors.TABLEAU_COLORS.keys())
-
     def __init__(self, data: Experiment | Dataset | Session, parent=None):
         super().__init__(parent)
         self.data = data
@@ -846,8 +847,8 @@ class LatencyWindowsDialog(QDialog):
         dur_spin.setSingleStep(0.05)
         dur_spin.setValue(window.durations[0])
         color_combo = QComboBox()
-        color_combo.addItems(self.COLOR_OPTIONS)
-        if window.color in self.COLOR_OPTIONS:
+        color_combo.addItems(COLOR_OPTIONS)
+        if window.color in COLOR_OPTIONS:
             color_combo.setCurrentText(window.color)
         remove_btn = QPushButton("Remove")
         remove_btn.clicked.connect(lambda: self._remove_window_group(group))

--- a/monstim_gui/gui_main.py
+++ b/monstim_gui/gui_main.py
@@ -22,8 +22,18 @@ from monstim_signals.core.utils import (format_report, get_output_path, get_data
                            get_source_path, get_docs_path, get_config_path, BIN_EXTENSION)
 
 from monstim_gui.splash import SPLASH_INFO
-from monstim_gui.dialogs import (ChangeChannelNamesDialog, ReflexSettingsDialog, CopyableReportDialog, SelectChannelsDialog,
-                                 LatexHelpWindow, AboutDialog, HelpWindow, PreferencesDialog, InvertChannelPolarityDialog)
+from monstim_gui.dialogs import (
+    ChangeChannelNamesDialog,
+    ReflexSettingsDialog,
+    CopyableReportDialog,
+    SelectChannelsDialog,
+    LatexHelpWindow,
+    AboutDialog,
+    HelpWindow,
+    PreferencesDialog,
+    InvertChannelPolarityDialog,
+    LatencyWindowsDialog,
+)
 from monstim_gui.menu_bar import MenuBar
 from monstim_gui.data_selection_widget import DataSelectionWidget
 from monstim_gui.reports_widget import ReportsWidget
@@ -203,7 +213,7 @@ class EMGAnalysisGUI(QMainWindow):
                     try:
                         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)  # Set cursor to busy
                         self.has_unsaved_changes = True
-                        self.status_bar.showMessage("Window settings updated successfully.", 5000)  # Show message for 5 seconds
+                        self.status_bar.showMessage("Window settings updated successfully.", 5000)
                         logging.debug("Window settings updated successfully.")
                     finally:
                         QApplication.restoreOverrideCursor()
@@ -211,6 +221,33 @@ class EMGAnalysisGUI(QMainWindow):
                 QMessageBox.warning(self, "Warning", "Please select a session first.")
         finally:
             QApplication.restoreOverrideCursor()
+
+    def manage_latency_windows(self, level: str):
+        logging.debug("Managing latency windows.")
+        match level:
+            case 'experiment':
+                if not self.current_experiment:
+                    QMessageBox.warning(self, "Warning", "Please select an experiment first.")
+                    return
+                emg_data = self.current_experiment
+            case 'dataset':
+                if not self.current_dataset:
+                    QMessageBox.warning(self, "Warning", "Please load a dataset first.")
+                    return
+                emg_data = self.current_dataset
+            case 'session':
+                if not self.current_session:
+                    QMessageBox.warning(self, "Warning", "Please select a session first.")
+                    return
+                emg_data = self.current_session
+            case _:
+                QMessageBox.warning(self, "Warning", "Invalid level for managing latency windows.")
+                return
+
+        dialog = LatencyWindowsDialog(emg_data, self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            self.has_unsaved_changes = True
+            self.status_bar.showMessage("Latency windows updated successfully.", 5000)
 
     def invert_channel_polarity(self, level : str):
         logging.debug("Inverting channel polarity.")

--- a/monstim_gui/menu_bar.py
+++ b/monstim_gui/menu_bar.py
@@ -74,8 +74,8 @@ class MenuBar(QMenuBar):
         session_menu = edit_menu.addMenu("Session")
 
         # Experiment level actions
-        update_window_action = experiment_menu.addAction("Update Reflex Time Windows")
-        update_window_action.triggered.connect(lambda: self.parent.update_reflex_time_windows('experiment'))
+        update_window_action = experiment_menu.addAction("Manage Latency Windows")
+        update_window_action.triggered.connect(lambda: self.parent.manage_latency_windows('experiment'))
         invert_polarity_action = experiment_menu.addAction("Invert Channel Polarity")
         invert_polarity_action.triggered.connect(lambda: self.parent.invert_channel_polarity('experiment'))
         change_names_action = experiment_menu.addAction("Change Channel Names")
@@ -87,8 +87,8 @@ class MenuBar(QMenuBar):
         remove_experiment_action.triggered.connect(self.parent.delete_experiment)
 
         # Dataset level actions
-        update_window_action = dataset_menu.addAction("Update Reflex Time Windows")
-        update_window_action.triggered.connect(lambda: self.parent.update_reflex_time_windows('dataset'))
+        update_window_action = dataset_menu.addAction("Manage Latency Windows")
+        update_window_action.triggered.connect(lambda: self.parent.manage_latency_windows('dataset'))
         invert_polarity_action = dataset_menu.addAction("Invert Channel Polarity")
         invert_polarity_action.triggered.connect(lambda: self.parent.invert_channel_polarity('dataset'))
         change_names_action = dataset_menu.addAction("Change Channel Names")
@@ -100,8 +100,8 @@ class MenuBar(QMenuBar):
         remove_dataset_action.triggered.connect(self.parent.remove_dataset)
 
         # Session level actions
-        update_window_action = session_menu.addAction("Update Reflex Time Windows")
-        update_window_action.triggered.connect(lambda: self.parent.update_reflex_time_windows('session'))
+        update_window_action = session_menu.addAction("Manage Latency Windows")
+        update_window_action.triggered.connect(lambda: self.parent.manage_latency_windows('session'))
         invert_polarity_action = session_menu.addAction("Invert Channel Polarity")
         invert_polarity_action.triggered.connect(lambda: self.parent.invert_channel_polarity('session'))
         change_names_action = session_menu.addAction("Change Channel Names")

--- a/monstim_signals/domain/session.py
+++ b/monstim_signals/domain/session.py
@@ -165,9 +165,62 @@ class Session:
     def latency_windows(self) -> List[LatencyWindow]:
         """
         Return the list of latency windows defined in the session annotations.
-        This includes M-wave and H-reflex windows.
         """
         return self.annot.latency_windows
+
+    # ------------------------------------------------------------------
+    # Latency window helper methods
+    # ------------------------------------------------------------------
+    def add_latency_window(self, name: str, start_times: List[float],
+                           durations: List[float], color: str | None = None,
+                           linestyle: str | None = None) -> None:
+        """Add a new :class:`LatencyWindow` to the session."""
+        window = LatencyWindow(
+            name=name,
+            start_times=start_times,
+            durations=durations,
+            color=color or self.m_color,
+            linestyle=linestyle or self.latency_window_style,
+        )
+        self.annot.latency_windows.append(window)
+        self.update_latency_window_parameters()
+        if self.repo is not None:
+            self.repo.save(self)
+
+    def remove_latency_window(self, name: str) -> None:
+        """Remove a latency window by name."""
+        self.annot.latency_windows = [
+            w for w in self.annot.latency_windows if w.name != name
+        ]
+        self.update_latency_window_parameters()
+        if self.repo is not None:
+            self.repo.save(self)
+
+    def get_latency_window(self, name: str) -> LatencyWindow | None:
+        for w in self.latency_windows:
+            if w.name == name:
+                return w
+        return None
+
+    def get_latency_window_amplitudes(
+        self, window_name: str, method: str, channel_index: int
+    ) -> List[float]:
+        """Return EMG amplitudes within ``window_name`` for each recording."""
+        window = self.get_latency_window(window_name)
+        if window is None:
+            raise ValueError(f"No latency window named '{window_name}' found.")
+        window_start = window.start_times[channel_index] + self.stim_start
+        window_end = window_start + window.durations[channel_index]
+        return [
+            calculate_emg_amplitude(
+                rec[:, channel_index],
+                window_start,
+                window_end,
+                self.scan_rate,
+                method=method,
+            )
+            for rec in self.recordings_filtered
+        ]
     @property
     def excluded_recordings(self):
         return set(self.annot.excluded_recordings)
@@ -302,14 +355,20 @@ class Session:
         
     def update_latency_window_parameters(self):
         '''
-        Update the M-wave and H-reflex start times and durations from the latency windows.
-        This is called after loading the session or when latency windows are modified.
+        Update cached M/H-response parameters from latency windows.
+        This remains for backwards compatibility. If no M-wave or H-reflex
+        windows exist, the corresponding attributes will be set to empty lists.
         '''
+        self.m_start = [0.0] * self.num_channels
+        self.m_duration = [0.0] * self.num_channels
+        self.h_start = [0.0] * self.num_channels
+        self.h_duration = [0.0] * self.num_channels
         for window in self.latency_windows:
-            if window.name == "M-wave":
+            lname = window.name.lower()
+            if lname in {"m-wave", "m_wave", "m wave", "mwave"}:
                 self.m_start = window.start_times
                 self.m_duration = window.durations
-            elif window.name == "H-reflex":
+            elif lname in {"h-reflex", "h_reflex", "h reflex", "hreflex"}:
                 self.h_start = window.start_times
                 self.h_duration = window.durations
 
@@ -456,13 +515,14 @@ class Session:
         self.reset_cached_reflex_properties()
 
     def change_reflex_latency_windows(self, m_start, m_duration, h_start, h_duration):
-        for window in self.latency_windows:
-            if window.name == "M-wave":
-                window.start_times = m_start
-                window.durations = m_duration
-            elif window.name == "H-reflex":
-                window.start_times = h_start
-                window.durations = h_duration
+        m_window = self.get_latency_window("M-wave")
+        if m_window:
+            m_window.start_times = m_start
+            m_window.durations = m_duration
+        h_window = self.get_latency_window("H-reflex")
+        if h_window:
+            h_window.start_times = h_start
+            h_window.durations = h_duration
         self.update_latency_window_parameters()
         if self.repo is not None:
             self.repo.save(self)


### PR DESCRIPTION
## Summary
- enable adding/removing arbitrary latency windows in Session and Dataset
- keep M/H support but calculate from latency window list
- add GUI action and dialog for editing latency windows
- rename menu option to **Manage Latency Windows**
- update docs mentioning new capability
- allow creating, removing, and changing latency windows via dialog and undo/redo
- refine latency window management so individual channel start times can be edited and color options are limited
- fix imports for latency window dialogs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6846ee338a4883258d2a346d0456e925