### PR TITLE
Improve latency window editing

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -25,8 +25,8 @@ m_max_args: # dict for get_avg_mmax() function. default is below.
 title_font_size : 16 # (int) font size of the plot title.
 axis_label_font_size : 16 # (int) font size of the axis labels.
 tick_font_size : 12 # (int) font size of the axis ticks.
-m_color : 'red' # (str) color of M-response flags and plots.
-h_color : 'blue' # (str) color of H-reflex flags and plots.
+m_color : 'tab:red' # (str) color of M-response flags and plots.
+h_color : 'tab:blue' # (str) color of H-reflex flags and plots.
 latency_window_style : ':' # (str) matplotlib linestyle character(s) for H/M-response flags.
 subplot_adjust_args: # dict fot subplots_adjust() function. default is below.
   left: 0.07


### PR DESCRIPTION
## Summary
- enable updating latency start times without closing the dialog
- replot data on Apply so adjustments are visualized immediately
- show color names without the `tab:` prefix in the latency window color picker
- use `tab` color codes for default M/H latency windows so they match other color settings
- display Tableau colors in the preferences dialog without the `tab:` prefix and convert user input safely

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847264c8c28832587288e2d493138da