### PR TITLE
Update from main

### DIFF
--- a/monstim_analysis/Transform_EMG.py
+++ b/monstim_analysis/Transform_EMG.py
@@ -275,7 +275,7 @@ def detect_plateau(x, y, max_window_size, min_window_size, threshold):
             plateau_start_idx = None
             plateau_end_idx = None
 
-    if plateau_start_idx and plateau_end_idx is not None:
+    if plateau_start_idx is not None and plateau_end_idx is not None:
         logging.info(f"Plateau region detected with window size {max_window_size}. Threshold: {threshold} times SD.")
         return plateau_start_idx, plateau_end_idx
     # Shrink the window size and retry if no plateau region is detected.


### PR DESCRIPTION
This pull request includes a minor but important bug fix in the `detect_plateau` function within the `monstim_analysis/Transform_EMG.py` file. The change ensures that the condition for detecting a plateau is evaluated correctly.

### Bug Fix:
* Corrected the logical condition in the `if` statement to explicitly check that both `plateau_start_idx` and `plateau_end_idx` are not `None`. This resolves a potential issue where the previous condition could evaluate incorrectly. (`[monstim_analysis/Transform_EMG.pyL278-R278](diffhunk://#diff-029c7314c02d01300e57211c01b3213b83cad74b2b2ff8da4bc0871ff5d5cb63L278-R278)`)