### PR TITLE
Add configurable latency window presets

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -58,3 +58,16 @@ h_duration: 1.5 # (in ms). default is 1.0.
 h_threshold: 0.5 # (in mV). default is 0.5.
 
 preferred_date_format: 'YYMMDD'
+latency_window_presets:
+  default:
+    - name: "M-wave"
+      start: 1.0
+      duration: 2.0
+      color: 'tab:red'
+      linestyle: ':'
+    - name: "H-reflex"
+      start: 3.2
+      duration: 1.5
+      color: 'tab:blue'
+      linestyle: ':'
+

--- a/monstim_signals/core/data_models.py
+++ b/monstim_signals/core/data_models.py
@@ -7,10 +7,7 @@ from monstim_signals.core.utils import DATA_VERSION
 # -----------------------------------------------------------------------
 # Basic data models for MonStim Signals
 # -----------------------------------------------------------------------
-@dataclass 
-# TODO: Add a method to create dataset latency window objects for each session in the dataset. Make the default windows be the m-wave and h-reflex windows.
-# TODO: Make the default windows be flexible user config settings (maybe a few sets of defaults to choose from based off the experiment types I'll work with).
-# TODO: Make the default be editable in the latency windows tab of the preferences dialog. Make it similar editor to the LatencyWindowManager, but with a few preset options.
+@dataclass
 class LatencyWindow:
     name: str
     color: str

--- a/monstim_signals/domain/dataset.py
+++ b/monstim_signals/domain/dataset.py
@@ -148,6 +148,15 @@ class Dataset:
             session.remove_latency_window(name)
         self.update_latency_window_parameters()
 
+    def apply_latency_window_preset(self, preset_name: str) -> None:
+        """Apply a latency window preset to all sessions in the dataset."""
+        if not self.sessions:
+            logging.warning(f"No sessions available to apply preset '{preset_name}' in dataset {self.id}.")
+            return
+        for session in self.sessions:
+            session.apply_latency_window_preset(preset_name)
+        self.update_latency_window_parameters()
+
     def get_latency_window(self, name: str) -> LatencyWindow | None:
         if not self.sessions:
             return None

--- a/monstim_signals/domain/experiment.py
+++ b/monstim_signals/domain/experiment.py
@@ -147,6 +147,12 @@ class Experiment:
         self._all_datasets = [ds for ds in self._all_datasets if ds.id != dataset_id]
         self.reset_all_caches()
 
+    def apply_latency_window_preset(self, preset_name: str) -> None:
+        """Apply a latency window preset to every dataset and session."""
+        for ds in self.datasets:
+            ds.apply_latency_window_preset(preset_name)
+        self.update_latency_window_parameters()
+
     def exclude_dataset(self, dataset_id: str) -> None:
         """Exclude a dataset from this experiment by its ID."""
         if dataset_id not in [ds.id for ds in self._all_datasets]:
@@ -294,7 +300,7 @@ class Experiment:
                 self.h_duration = window.durations
         for ds in self.datasets:
             ds.update_latency_window_parameters()
-    
+
     def rename_channels(self, new_names: dict[str, str]) -> None:
         """
         Rename channels in all datasets based on a mapping provided in new_names.


### PR DESCRIPTION
## Summary
- support presets for latency windows
- allow editing latency window presets in Preferences dialog
- avoid automatic window creation for sessions
- add utilities to apply presets to sessions, datasets, and experiments
- enable preset selection in the latency window manager dialog
- document default preset in the configuration file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849cbcd01608325bbde7b94fed746bd