### PR TITLE
Refactor of Metadata Editor and Small Bugfixes

### DIFF
--- a/monstim_gui/commands.py
+++ b/monstim_gui/commands.py
@@ -1411,3 +1411,144 @@ class ToggleCompletionStatusCommand(Command):
     def get_description(self) -> str:
         action = "completed" if self.new_status else "marked incomplete"
         return f"Marked {self.level} '{self.target_id}' as {action}"
+
+
+class EditDatasetMetadataCommand(Command):
+    """Command to edit dataset metadata (date, animal ID, condition) with optional folder rename."""
+
+    def __init__(
+        self,
+        gui,
+        dataset,
+        old_date: str | None,
+        new_date: str | None,
+        old_animal_id: str | None,
+        new_animal_id: str | None,
+        old_condition: str | None,
+        new_condition: str | None,
+        old_folder_name: str | None = None,
+        new_folder_name: str | None = None,
+    ):
+        """Initialize the edit metadata command.
+
+        Args:
+            gui: The main GUI instance
+            dataset: The Dataset object to modify
+            old_date: Previous date string (YYYY-MM-DD format)
+            new_date: New date string (YYYY-MM-DD format)
+            old_animal_id: Previous animal ID
+            new_animal_id: New animal ID
+            old_condition: Previous condition
+            new_condition: New condition
+            old_folder_name: Original folder name (if renaming)
+            new_folder_name: New folder name (if renaming)
+        """
+        self.gui = gui
+        self.dataset = dataset
+        self.old_date = old_date
+        self.new_date = new_date
+        self.old_animal_id = old_animal_id
+        self.new_animal_id = new_animal_id
+        self.old_condition = old_condition
+        self.new_condition = new_condition
+        self.old_folder_name = old_folder_name
+        self.new_folder_name = new_folder_name
+
+        # Build command name
+        parts = []
+        if old_date != new_date:
+            parts.append(f"date: {old_date} → {new_date}")
+        if old_animal_id != new_animal_id:
+            parts.append(f"ID: {old_animal_id} → {new_animal_id}")
+        if old_condition != new_condition:
+            parts.append(f"condition: {old_condition} → {new_condition}")
+
+        if parts:
+            self.command_name = f"Edit Dataset Metadata ({', '.join(parts)})"
+        else:
+            self.command_name = "Edit Dataset Metadata"
+
+    def _apply_metadata(self, date: str | None, animal_id: str | None, condition: str | None, folder_name: str | None):
+        """Apply metadata changes and optionally rename folder.
+
+        Args:
+            date: Date to set
+            animal_id: Animal ID to set
+            condition: Condition to set
+            folder_name: Target folder name (None if no rename needed)
+        """
+        import errno
+
+        # Update annotation
+        self.dataset.annot.date = date
+        self.dataset.annot.animal_id = animal_id
+        self.dataset.annot.condition = condition
+
+        # Rename folder if needed
+        if folder_name and self.dataset.repo:
+            current_folder = self.dataset.repo.folder  # Already a Path object
+            if current_folder.name != folder_name:
+                new_folder_path = current_folder.parent / folder_name
+
+                # Check if target exists
+                if new_folder_path.exists():
+                    raise FileExistsError(f"Target folder already exists: {new_folder_path}")
+
+                try:
+                    # Use repository rename with retry logic
+                    self.dataset.repo.rename(new_folder_path, dataset=self.dataset)
+                    logging.info(f"Renamed dataset folder: {current_folder.name} → {folder_name}")
+                except OSError as e:
+                    if getattr(e, "errno", None) == errno.EACCES:
+                        raise OSError(
+                            f"Cannot rename folder - it is in use. " f"Please close any programs accessing: {current_folder}"
+                        ) from e
+                    raise
+
+        # Save annotation changes
+        if self.dataset.repo:
+            self.dataset.repo.save(self.dataset)
+            logging.info(
+                f"Updated metadata for dataset '{self.dataset.id}': "
+                f"date={date}, animal_id={animal_id}, condition={condition}"
+            )
+
+    def execute(self):
+        """Apply the new metadata and folder name."""
+        try:
+            self._apply_metadata(self.new_date, self.new_animal_id, self.new_condition, self.new_folder_name)
+
+            # Refresh UI to show updated display name
+            if hasattr(self.gui, "data_selection_widget"):
+                self.gui.data_selection_widget.update(levels=("dataset", "session"))
+
+        except Exception as e:
+            logging.error(f"Failed to apply dataset metadata changes: {e}", exc_info=True)
+            raise
+
+    def undo(self):
+        """Revert to the old metadata and folder name."""
+        try:
+            self._apply_metadata(self.old_date, self.old_animal_id, self.old_condition, self.old_folder_name)
+
+            # Refresh UI to show reverted display name
+            if hasattr(self.gui, "data_selection_widget"):
+                self.gui.data_selection_widget.update(levels=("dataset", "session"))
+
+        except Exception as e:
+            logging.error(f"Failed to undo dataset metadata changes: {e}", exc_info=True)
+            raise Exception(f"Failed to undo dataset metadata changes: {str(e)}")
+
+    def get_description(self) -> str:
+        """Return a human-readable description of this command."""
+        parts = []
+        if self.old_date != self.new_date:
+            parts.append(f"date to {self.new_date}")
+        if self.old_animal_id != self.new_animal_id:
+            parts.append(f"ID to {self.new_animal_id}")
+        if self.old_condition != self.new_condition:
+            parts.append(f"condition to {self.new_condition}")
+
+        if parts:
+            return f"Changed dataset {', '.join(parts)}"
+        return "Modified dataset metadata"

--- a/monstim_gui/plotting/plotting_cycler.py
+++ b/monstim_gui/plotting/plotting_cycler.py
@@ -74,7 +74,7 @@ class RecordingCyclerWidget(QGroupBox):
         super().__init__("Recording Cycler", parent)
 
         self.gui: "MonstimGUI" = get_main_window()
-        if not self.gui.current_session:
+        if not self.gui or not self.gui.current_session:
             self.max_recording_idxs = 0
         else:
             self.max_recording_idxs = self.gui.current_session.num_all_recordings - 1
@@ -138,7 +138,7 @@ class RecordingCyclerWidget(QGroupBox):
         self.recording_spinbox.valueChanged.connect(self.on_recording_changed)
 
     def reset_max_recordings(self):
-        if not self.gui.current_session:
+        if not self.gui or not self.gui.current_session:
             self.max_recording_idxs = 0
         else:
             self.max_recording_idxs = max(0, self.gui.current_session.num_all_recordings - 1)
@@ -168,6 +168,8 @@ class RecordingCyclerWidget(QGroupBox):
             self.recording_spinbox.setValue(self.recording_spinbox.value() + self.step_size.value())
 
     def on_exclude(self):
+        if not self.gui or not self.gui.current_session:
+            return
         selected_recording_id = self.gui.current_session.all_recordings[self.recording_spinbox.value()].id
         logging.info(f"Excluding/including recording ID {selected_recording_id}")
         logging.info(f"Current excluded recordings: {self.gui.current_session.excluded_recordings}")
@@ -189,10 +191,11 @@ class RecordingCyclerWidget(QGroupBox):
             value = max_val
         self._refresh_exclude_button(value)
 
-        self.gui.plot_controller.plot_data()
+        if self.gui and self.gui.plot_controller:
+            self.gui.plot_controller.plot_data()
 
     def _refresh_exclude_button(self, recording_index):
-        if self.gui.current_session and self.gui.current_session.all_recordings:
+        if self.gui and self.gui.current_session and self.gui.current_session.all_recordings:
             # Translate index -> recording id before checking exclusion list
             if 0 <= recording_index < len(self.gui.current_session.all_recordings):
                 rec_id = self.gui.current_session.all_recordings[recording_index].id

--- a/monstim_gui/plotting/plotting_widget.py
+++ b/monstim_gui/plotting/plotting_widget.py
@@ -323,15 +323,15 @@ class PlotWidget(QGroupBox):
             # Get the current plot type
             plot_type = self.plot_type_combo.currentText()
 
-            # Skip if no plot type selected
-            if not plot_type:
-                return
-
             # Remove the current widget if it exists
             if self.current_option_widget:
                 self.options_layout.removeWidget(self.current_option_widget)
                 self.current_option_widget.deleteLater()
                 self.current_option_widget = None
+
+            # Skip if no plot type selected
+            if not plot_type:
+                return
 
             # Create a new widget with the same plot type
             if plot_type in self.plot_options[self.view]:

--- a/monstim_gui/plotting/plotting_widget.py
+++ b/monstim_gui/plotting/plotting_widget.py
@@ -320,68 +320,70 @@ class PlotWidget(QGroupBox):
         This should refresh the current plot options widget without changing saved options.
         """
         try:
-            # Just refresh the current widget without changing saved options
+            # Get the current plot type
             plot_type = self.plot_type_combo.currentText()
-            if plot_type and self.current_option_widget:
-                # Remove the current widget
+
+            # Skip if no plot type selected
+            if not plot_type:
+                return
+
+            # Remove the current widget if it exists
+            if self.current_option_widget:
                 self.options_layout.removeWidget(self.current_option_widget)
                 self.current_option_widget.deleteLater()
                 self.current_option_widget = None
 
-                # Create a new widget with the same plot type
-                if plot_type in self.plot_options[self.view]:
-                    self.current_option_widget = self.plot_options[self.view][plot_type](self)
-                    self.options_layout.addWidget(self.current_option_widget)
+            # Create a new widget with the same plot type
+            if plot_type in self.plot_options[self.view]:
+                self.current_option_widget = self.plot_options[self.view][plot_type](self)
+                self.options_layout.addWidget(self.current_option_widget)
 
-                    # Restore the saved options for this view and plot type
-                    if plot_type in self.last_options[self.view] and self.last_options[self.view][plot_type]:
-                        try:
-                            saved_options = self.last_options[self.view][plot_type]
+                # Restore the saved options for this view and plot type
+                if plot_type in self.last_options[self.view] and self.last_options[self.view][plot_type]:
+                    try:
+                        saved_options = self.last_options[self.view][plot_type]
 
-                            # Filter options to only include those that are valid for this plot type
-                            default_options = self.current_option_widget.get_options()
-                            filtered_options = {k: v for k, v in saved_options.items() if k in default_options}
+                        # Filter options to only include those that are valid for this plot type
+                        default_options = self.current_option_widget.get_options()
+                        filtered_options = {k: v for k, v in saved_options.items() if k in default_options}
 
-                            # Use persistent channel selection instead of view-specific selection
-                            if "channel_indices" in filtered_options and hasattr(self, "persistent_channel_selection"):
-                                filtered_options["channel_indices"] = self.persistent_channel_selection
+                        # Use persistent channel selection instead of view-specific selection
+                        if "channel_indices" in filtered_options and hasattr(self, "persistent_channel_selection"):
+                            filtered_options["channel_indices"] = self.persistent_channel_selection
 
-                            self.current_option_widget.set_options(filtered_options)
-                        except Exception as e:
-                            logging.warning(f"Failed to restore options for {self.view} - {plot_type}: {e}")
-                    else:
-                        # Apply persistent channel selection even if no other saved options exist
-                        if hasattr(self, "persistent_channel_selection") and hasattr(
-                            self.current_option_widget, "channel_selector"
-                        ):
-                            # If persistent selection is empty (first load), populate with all available channels
-                            if not self.persistent_channel_selection:
-                                all_channels = self.current_option_widget.channel_selector.get_selected_channels()
-                                if all_channels:  # Only update if there are channels available
-                                    self.persistent_channel_selection = all_channels
-                                    logging.debug(f"First load: auto-selected all {len(all_channels)} channels")
-                            else:
-                                self.current_option_widget.channel_selector.set_selected_channels(
-                                    self.persistent_channel_selection
-                                )
+                        self.current_option_widget.set_options(filtered_options)
+                    except Exception as e:
+                        logging.warning(f"Failed to restore options for {self.view} - {plot_type}: {e}")
+                else:
+                    # Apply persistent channel selection even if no other saved options exist
+                    if hasattr(self, "persistent_channel_selection") and hasattr(
+                        self.current_option_widget, "channel_selector"
+                    ):
+                        # If persistent selection is empty (first load), populate with all available channels
+                        if not self.persistent_channel_selection:
+                            all_channels = self.current_option_widget.channel_selector.get_selected_channels()
+                            if all_channels:  # Only update if there are channels available
+                                self.persistent_channel_selection = all_channels
+                                logging.debug(f"First load: auto-selected all {len(all_channels)} channels")
+                        else:
+                            self.current_option_widget.channel_selector.set_selected_channels(
+                                self.persistent_channel_selection
+                            )
 
-                    # Connect channel selection updates for real-time persistence
-                    self.connect_channel_selection_updates()
+                # Connect channel selection updates for real-time persistence
+                self.connect_channel_selection_updates()
 
-                    # Connect option change signals so modifications are saved immediately
-                    self.connect_option_change_signals()
+                # Connect option change signals so modifications are saved immediately
+                self.connect_option_change_signals()
 
-                    # Connect option change signals so modifications are saved immediately
-                    self.connect_option_change_signals()
+                self.options_layout.update()
 
-                    self.options_layout.update()
+                # Handle special case for Single EMG Recordings
+                if plot_type == "Single EMG Recordings":
+                    self.current_option_widget.recording_cycler.reset_max_recordings()
 
-                    # Handle special case for Single EMG Recordings
-                    if plot_type == "Single EMG Recordings":
-                        self.current_option_widget.recording_cycler.reset_max_recordings()
-
-        except AttributeError:
-            pass
+        except AttributeError as e:
+            logging.warning(f"Error refreshing plot options widget: {e}", exc_info=True)
 
     def update_plot_types(self):
         self.plot_type_combo.blockSignals(True)

--- a/tests/commands_tests/test_all_commands_coverage.py
+++ b/tests/commands_tests/test_all_commands_coverage.py
@@ -40,6 +40,7 @@ EXPECTED_COMMANDS = {
     "DeleteDatasetCommand",
     "ToggleDatasetInclusionCommand",
     "ToggleCompletionStatusCommand",
+    "EditDatasetMetadataCommand",
 }
 
 

--- a/tests/commands_tests/test_edit_dataset_metadata_command.py
+++ b/tests/commands_tests/test_edit_dataset_metadata_command.py
@@ -10,7 +10,7 @@ These tests verify that:
 """
 
 from pathlib import Path
-from unittest.mock import Mock, PropertyMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -97,21 +97,21 @@ class TestEditDatasetMetadataCommand:
         mock_dataset.repo = Mock()
 
         # Mock the folder path - need to properly mock Path behavior
-        old_folder = Mock(spec=Path)
+        old_folder = MagicMock(spec=Path)
         old_folder.name = "240115 C123 control"
-        parent_folder = Mock(spec=Path)
+        parent_folder = MagicMock(spec=Path)
 
-        # Mock the / operator for parent / folder_name
-        def parent_div(self_arg, folder_name):
-            new_path = Mock(spec=Path)
+        # Mock the / operator for parent / folder_name using side_effect
+        def parent_div(folder_name):
+            new_path = MagicMock(spec=Path)
             new_path.name = folder_name
             new_path.exists.return_value = False
             return new_path
 
-        parent_folder.__truediv__ = parent_div
+        parent_folder.__truediv__.side_effect = parent_div
         old_folder.parent = parent_folder
 
-        type(mock_dataset.repo).folder = PropertyMock(return_value=old_folder)
+        mock_dataset.repo.folder = old_folder
 
         # Create command with folder rename
         cmd = EditDatasetMetadataCommand(
@@ -163,21 +163,21 @@ class TestEditDatasetMetadataCommand:
         mock_dataset.repo = Mock()
 
         # Mock the folder path
-        old_folder = Mock(spec=Path)
+        old_folder = MagicMock(spec=Path)
         old_folder.name = "240115 C123 control"
-        parent_folder = Mock(spec=Path)
+        parent_folder = MagicMock(spec=Path)
 
-        # Mock the / operator to return a path that exists
-        def parent_div(self_arg, folder_name):
-            new_path = Mock(spec=Path)
+        # Mock the / operator to return a path that exists using side_effect
+        def parent_div(folder_name):
+            new_path = MagicMock(spec=Path)
             new_path.name = folder_name
             new_path.exists.return_value = True  # Target already exists
             return new_path
 
-        parent_folder.__truediv__ = parent_div
+        parent_folder.__truediv__.side_effect = parent_div
         old_folder.parent = parent_folder
 
-        type(mock_dataset.repo).folder = PropertyMock(return_value=old_folder)
+        mock_dataset.repo.folder = old_folder
 
         # Create command with folder rename
         cmd = EditDatasetMetadataCommand(
@@ -209,21 +209,21 @@ class TestEditDatasetMetadataCommand:
         mock_dataset.repo = Mock()
 
         # After execute, folder has been renamed to new name
-        new_folder = Mock(spec=Path)
+        new_folder = MagicMock(spec=Path)
         new_folder.name = "240116 C456 test"
-        parent_folder = Mock(spec=Path)
+        parent_folder = MagicMock(spec=Path)
 
-        # Mock the / operator for parent / folder_name
-        def parent_div(self_arg, folder_name):
-            path = Mock(spec=Path)
+        # Mock the / operator for parent / folder_name using side_effect
+        def parent_div(folder_name):
+            path = MagicMock(spec=Path)
             path.name = folder_name
             path.exists.return_value = False
             return path
 
-        parent_folder.__truediv__ = parent_div
+        parent_folder.__truediv__.side_effect = parent_div
         new_folder.parent = parent_folder
 
-        type(mock_dataset.repo).folder = PropertyMock(return_value=new_folder)
+        mock_dataset.repo.folder = new_folder
 
         # Create command
         cmd = EditDatasetMetadataCommand(
@@ -372,21 +372,21 @@ class TestEditDatasetMetadataCommand:
         mock_dataset.repo = Mock()
 
         # Mock the folder path
-        old_folder = Mock(spec=Path)
+        old_folder = MagicMock(spec=Path)
         old_folder.name = "240115 C123 control"
-        parent_folder = Mock(spec=Path)
+        parent_folder = MagicMock(spec=Path)
 
-        # Mock the / operator
-        def parent_div(self_arg, folder_name):
-            new_path = Mock(spec=Path)
+        # Mock the / operator using side_effect
+        def parent_div(folder_name):
+            new_path = MagicMock(spec=Path)
             new_path.name = folder_name
             new_path.exists.return_value = False
             return new_path
 
-        parent_folder.__truediv__ = parent_div
+        parent_folder.__truediv__.side_effect = parent_div
         old_folder.parent = parent_folder
 
-        type(mock_dataset.repo).folder = PropertyMock(return_value=old_folder)
+        mock_dataset.repo.folder = old_folder
 
         # Make repo.rename raise access denied error
         access_error = OSError("Access denied")

--- a/tests/commands_tests/test_edit_dataset_metadata_command.py
+++ b/tests/commands_tests/test_edit_dataset_metadata_command.py
@@ -1,0 +1,443 @@
+"""
+Tests for EditDatasetMetadataCommand.
+
+These tests verify that:
+1. Metadata-only changes work correctly
+2. Metadata + folder rename works correctly
+3. Undo properly reverts both metadata and folder name
+4. UI refresh is triggered after execute and undo
+5. Error handling works correctly
+"""
+
+from pathlib import Path
+from unittest.mock import Mock, PropertyMock
+
+import pytest
+
+from monstim_gui.commands import EditDatasetMetadataCommand
+
+
+class TestEditDatasetMetadataCommand:
+    """Test suite for EditDatasetMetadataCommand."""
+
+    def test_metadata_only_no_folder_rename(self):
+        """Test editing metadata without renaming the folder."""
+        # Setup mocks
+        mock_gui = Mock()
+        mock_gui.data_selection_widget = Mock()
+
+        mock_dataset = Mock()
+        mock_dataset.annot = Mock()
+        mock_dataset.annot.date = "2024-01-15"
+        mock_dataset.annot.animal_id = "C123"
+        mock_dataset.annot.condition = "control"
+        mock_dataset.repo = Mock()
+
+        # Create command to change metadata only (no folder rename)
+        cmd = EditDatasetMetadataCommand(
+            gui=mock_gui,
+            dataset=mock_dataset,
+            old_date="2024-01-15",
+            new_date="2024-01-16",
+            old_animal_id="C123",
+            new_animal_id="C123",
+            old_condition="control",
+            new_condition="test",
+            old_folder_name=None,
+            new_folder_name=None,
+        )
+
+        # Execute
+        cmd.execute()
+
+        # Verify metadata was updated
+        assert mock_dataset.annot.date == "2024-01-16"
+        assert mock_dataset.annot.animal_id == "C123"
+        assert mock_dataset.annot.condition == "test"
+
+        # Verify repo.save was called
+        mock_dataset.repo.save.assert_called_once_with(mock_dataset)
+
+        # Verify repo.rename was NOT called (no folder rename)
+        mock_dataset.repo.rename.assert_not_called()
+
+        # Verify UI was refreshed
+        mock_gui.data_selection_widget.update.assert_called_once_with(levels=("dataset", "session"))
+
+        # Reset mocks for undo
+        mock_dataset.repo.save.reset_mock()
+        mock_gui.data_selection_widget.update.reset_mock()
+
+        # Undo
+        cmd.undo()
+
+        # Verify metadata was reverted
+        assert mock_dataset.annot.date == "2024-01-15"
+        assert mock_dataset.annot.animal_id == "C123"
+        assert mock_dataset.annot.condition == "control"
+
+        # Verify repo.save was called again
+        mock_dataset.repo.save.assert_called_once_with(mock_dataset)
+
+        # Verify UI was refreshed again
+        mock_gui.data_selection_widget.update.assert_called_once_with(levels=("dataset", "session"))
+
+    def test_metadata_with_folder_rename(self):
+        """Test editing metadata that requires folder rename."""
+        # Setup mocks
+        mock_gui = Mock()
+        mock_gui.data_selection_widget = Mock()
+
+        mock_dataset = Mock()
+        mock_dataset.annot = Mock()
+        mock_dataset.annot.date = "2024-01-15"
+        mock_dataset.annot.animal_id = "C123"
+        mock_dataset.annot.condition = "control"
+        mock_dataset.id = "240115 C123 control"
+        mock_dataset.repo = Mock()
+
+        # Mock the folder path - need to properly mock Path behavior
+        old_folder = Mock(spec=Path)
+        old_folder.name = "240115 C123 control"
+        parent_folder = Mock(spec=Path)
+
+        # Mock the / operator for parent / folder_name
+        def parent_div(self_arg, folder_name):
+            new_path = Mock(spec=Path)
+            new_path.name = folder_name
+            new_path.exists.return_value = False
+            return new_path
+
+        parent_folder.__truediv__ = parent_div
+        old_folder.parent = parent_folder
+
+        type(mock_dataset.repo).folder = PropertyMock(return_value=old_folder)
+
+        # Create command with folder rename
+        cmd = EditDatasetMetadataCommand(
+            gui=mock_gui,
+            dataset=mock_dataset,
+            old_date="2024-01-15",
+            new_date="2024-01-16",
+            old_animal_id="C123",
+            new_animal_id="C456",
+            old_condition="control",
+            new_condition="test",
+            old_folder_name="240115 C123 control",
+            new_folder_name="240116 C456 test",
+        )
+
+        # Execute
+        cmd.execute()
+
+        # Verify metadata was updated
+        assert mock_dataset.annot.date == "2024-01-16"
+        assert mock_dataset.annot.animal_id == "C456"
+        assert mock_dataset.annot.condition == "test"
+
+        # Verify repo.rename was called with new folder name
+        mock_dataset.repo.rename.assert_called_once()
+        call_args = mock_dataset.repo.rename.call_args
+        # First argument should be the new folder path
+        assert call_args[0][0].name == "240116 C456 test"
+        # dataset parameter should be passed
+        assert call_args[1]["dataset"] == mock_dataset
+
+        # Verify repo.save was called
+        mock_dataset.repo.save.assert_called_once_with(mock_dataset)
+
+        # Verify UI was refreshed
+        mock_gui.data_selection_widget.update.assert_called_once_with(levels=("dataset", "session"))
+
+    def test_folder_already_exists_error(self):
+        """Test that FileExistsError is raised if target folder already exists."""
+        # Setup mocks
+        mock_gui = Mock()
+        mock_gui.data_selection_widget = Mock()
+
+        mock_dataset = Mock()
+        mock_dataset.annot = Mock()
+        mock_dataset.annot.date = "2024-01-15"
+        mock_dataset.annot.animal_id = "C123"
+        mock_dataset.annot.condition = "control"
+        mock_dataset.repo = Mock()
+
+        # Mock the folder path
+        old_folder = Mock(spec=Path)
+        old_folder.name = "240115 C123 control"
+        parent_folder = Mock(spec=Path)
+
+        # Mock the / operator to return a path that exists
+        def parent_div(self_arg, folder_name):
+            new_path = Mock(spec=Path)
+            new_path.name = folder_name
+            new_path.exists.return_value = True  # Target already exists
+            return new_path
+
+        parent_folder.__truediv__ = parent_div
+        old_folder.parent = parent_folder
+
+        type(mock_dataset.repo).folder = PropertyMock(return_value=old_folder)
+
+        # Create command with folder rename
+        cmd = EditDatasetMetadataCommand(
+            gui=mock_gui,
+            dataset=mock_dataset,
+            old_date="2024-01-15",
+            new_date="2024-01-16",
+            old_animal_id="C123",
+            new_animal_id="C456",
+            old_condition="control",
+            new_condition="test",
+            old_folder_name="240115 C123 control",
+            new_folder_name="240116 C456 test",
+        )
+
+        # Execute should raise FileExistsError
+        with pytest.raises(FileExistsError, match="Target folder already exists"):
+            cmd.execute()
+
+    def test_undo_with_folder_rename(self):
+        """Test that undo properly reverts folder rename."""
+        # Setup mocks
+        mock_gui = Mock()
+        mock_gui.data_selection_widget = Mock()
+
+        mock_dataset = Mock()
+        mock_dataset.annot = Mock()
+        mock_dataset.id = "240116 C456 test"
+        mock_dataset.repo = Mock()
+
+        # After execute, folder has been renamed to new name
+        new_folder = Mock(spec=Path)
+        new_folder.name = "240116 C456 test"
+        parent_folder = Mock(spec=Path)
+
+        # Mock the / operator for parent / folder_name
+        def parent_div(self_arg, folder_name):
+            path = Mock(spec=Path)
+            path.name = folder_name
+            path.exists.return_value = False
+            return path
+
+        parent_folder.__truediv__ = parent_div
+        new_folder.parent = parent_folder
+
+        type(mock_dataset.repo).folder = PropertyMock(return_value=new_folder)
+
+        # Create command
+        cmd = EditDatasetMetadataCommand(
+            gui=mock_gui,
+            dataset=mock_dataset,
+            old_date="2024-01-15",
+            new_date="2024-01-16",
+            old_animal_id="C123",
+            new_animal_id="C456",
+            old_condition="control",
+            new_condition="test",
+            old_folder_name="240115 C123 control",
+            new_folder_name="240116 C456 test",
+        )
+
+        # Simulate state after execute (metadata already changed)
+        mock_dataset.annot.date = "2024-01-16"
+        mock_dataset.annot.animal_id = "C456"
+        mock_dataset.annot.condition = "test"
+
+        # Undo
+        cmd.undo()
+
+        # Verify metadata was reverted
+        assert mock_dataset.annot.date == "2024-01-15"
+        assert mock_dataset.annot.animal_id == "C123"
+        assert mock_dataset.annot.condition == "control"
+
+        # Verify repo.rename was called to rename back
+        mock_dataset.repo.rename.assert_called_once()
+        call_args = mock_dataset.repo.rename.call_args
+        # Should rename back to old folder name
+        assert call_args[0][0].name == "240115 C123 control"
+        assert call_args[1]["dataset"] == mock_dataset
+
+        # Verify repo.save was called
+        mock_dataset.repo.save.assert_called_once_with(mock_dataset)
+
+        # Verify UI was refreshed
+        mock_gui.data_selection_widget.update.assert_called_once_with(levels=("dataset", "session"))
+
+    def test_no_repo_metadata_only(self):
+        """Test that command works when dataset has no repository (metadata-only mode)."""
+        # Setup mocks
+        mock_gui = Mock()
+        mock_gui.data_selection_widget = Mock()
+
+        mock_dataset = Mock()
+        mock_dataset.annot = Mock()
+        mock_dataset.annot.date = "2024-01-15"
+        mock_dataset.annot.animal_id = "C123"
+        mock_dataset.annot.condition = "control"
+        mock_dataset.repo = None  # No repository
+
+        # Create command (no folder rename when repo is None)
+        cmd = EditDatasetMetadataCommand(
+            gui=mock_gui,
+            dataset=mock_dataset,
+            old_date="2024-01-15",
+            new_date="2024-01-16",
+            old_animal_id="C123",
+            new_animal_id="C456",
+            old_condition="control",
+            new_condition="test",
+            old_folder_name=None,
+            new_folder_name=None,
+        )
+
+        # Execute should work without errors
+        cmd.execute()
+
+        # Verify metadata was updated
+        assert mock_dataset.annot.date == "2024-01-16"
+        assert mock_dataset.annot.animal_id == "C456"
+        assert mock_dataset.annot.condition == "test"
+
+        # UI should still be refreshed
+        mock_gui.data_selection_widget.update.assert_called_once_with(levels=("dataset", "session"))
+
+    def test_command_name_generation(self):
+        """Test that command name is generated correctly."""
+        mock_gui = Mock()
+        mock_dataset = Mock()
+
+        # Test with all fields changed
+        cmd = EditDatasetMetadataCommand(
+            gui=mock_gui,
+            dataset=mock_dataset,
+            old_date="2024-01-15",
+            new_date="2024-01-16",
+            old_animal_id="C123",
+            new_animal_id="C456",
+            old_condition="control",
+            new_condition="test",
+        )
+        assert "date: 2024-01-15 → 2024-01-16" in cmd.command_name
+        assert "ID: C123 → C456" in cmd.command_name
+        assert "condition: control → test" in cmd.command_name
+
+        # Test with only date changed
+        cmd = EditDatasetMetadataCommand(
+            gui=mock_gui,
+            dataset=mock_dataset,
+            old_date="2024-01-15",
+            new_date="2024-01-16",
+            old_animal_id="C123",
+            new_animal_id="C123",
+            old_condition="test",
+            new_condition="test",
+        )
+        assert "date: 2024-01-15 → 2024-01-16" in cmd.command_name
+        assert "ID:" not in cmd.command_name
+        assert "condition:" not in cmd.command_name
+
+    def test_get_description(self):
+        """Test that get_description returns a meaningful description."""
+        mock_gui = Mock()
+        mock_dataset = Mock()
+
+        cmd = EditDatasetMetadataCommand(
+            gui=mock_gui,
+            dataset=mock_dataset,
+            old_date="2024-01-15",
+            new_date="2024-01-16",
+            old_animal_id="C123",
+            new_animal_id="C456",
+            old_condition="control",
+            new_condition="test",
+        )
+
+        description = cmd.get_description()
+        assert "date to 2024-01-16" in description
+        assert "ID to C456" in description
+        assert "condition to test" in description
+
+    def test_access_denied_error_handling(self):
+        """Test that OSError with EACCES is properly handled."""
+        import errno
+
+        # Setup mocks
+        mock_gui = Mock()
+        mock_gui.data_selection_widget = Mock()
+
+        mock_dataset = Mock()
+        mock_dataset.annot = Mock()
+        mock_dataset.repo = Mock()
+
+        # Mock the folder path
+        old_folder = Mock(spec=Path)
+        old_folder.name = "240115 C123 control"
+        parent_folder = Mock(spec=Path)
+
+        # Mock the / operator
+        def parent_div(self_arg, folder_name):
+            new_path = Mock(spec=Path)
+            new_path.name = folder_name
+            new_path.exists.return_value = False
+            return new_path
+
+        parent_folder.__truediv__ = parent_div
+        old_folder.parent = parent_folder
+
+        type(mock_dataset.repo).folder = PropertyMock(return_value=old_folder)
+
+        # Make repo.rename raise access denied error
+        access_error = OSError("Access denied")
+        access_error.errno = errno.EACCES
+        mock_dataset.repo.rename.side_effect = access_error
+
+        # Create command with folder rename
+        cmd = EditDatasetMetadataCommand(
+            gui=mock_gui,
+            dataset=mock_dataset,
+            old_date="2024-01-15",
+            new_date="2024-01-16",
+            old_animal_id="C123",
+            new_animal_id="C456",
+            old_condition="control",
+            new_condition="test",
+            old_folder_name="240115 C123 control",
+            new_folder_name="240116 C456 test",
+        )
+
+        # Execute should raise OSError with helpful message
+        with pytest.raises(OSError, match="Cannot rename folder - it is in use"):
+            cmd.execute()
+
+    def test_ui_refresh_without_data_selection_widget(self):
+        """Test that command doesn't fail if GUI has no data_selection_widget."""
+        # Setup mocks - GUI without data_selection_widget
+        mock_gui = Mock(spec=[])  # Empty spec means no attributes
+
+        mock_dataset = Mock()
+        mock_dataset.annot = Mock()
+        mock_dataset.annot.date = "2024-01-15"
+        mock_dataset.annot.animal_id = "C123"
+        mock_dataset.annot.condition = "control"
+        mock_dataset.repo = Mock()
+
+        # Create command
+        cmd = EditDatasetMetadataCommand(
+            gui=mock_gui,
+            dataset=mock_dataset,
+            old_date="2024-01-15",
+            new_date="2024-01-16",
+            old_animal_id="C123",
+            new_animal_id="C123",
+            old_condition="control",
+            new_condition="test",
+        )
+
+        # Execute should not raise error even without data_selection_widget
+        cmd.execute()
+
+        # Verify metadata was still updated
+        assert mock_dataset.annot.date == "2024-01-16"
+        mock_dataset.repo.save.assert_called_once_with(mock_dataset)


### PR DESCRIPTION
## Description

This pull request introduces a new undoable command for editing dataset metadata, refactors the dataset metadata editor dialog to support command-based changes, and improves robustness in several GUI components. The most significant change is the addition of the `EditDatasetMetadataCommand`, which enables undo/redo for metadata edits and folder renames, ensuring consistency and reliability. The dialog and manager logic have been updated to leverage this command, and minor improvements have been made to plotting widgets and cyclers for better error handling and initialization.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Build/CI changes


## Changes Made

**Dataset Metadata Editing (Core Functionality):**
* Added `EditDatasetMetadataCommand` in `monstim_gui/commands.py`, enabling undo/redo for edits to dataset date, animal ID, condition, and folder renames. This centralizes metadata updates and folder renaming logic, improving reliability and error handling.
* Refactored `DatasetMetadataEditor` dialog to collect old and new metadata values, and to prepare for command-based execution rather than directly modifying dataset objects. Folder rename logic is now deferred to the command. [[1]](diffhunk://#diff-3ca837af0763fb487950289ee9100b94c60cad10d261ee3d8c6696a7a660364fR36-R47) [[2]](diffhunk://#diff-3ca837af0763fb487950289ee9100b94c60cad10d261ee3d8c6696a7a660364fL251-R260) [[3]](diffhunk://#diff-3ca837af0763fb487950289ee9100b94c60cad10d261ee3d8c6696a7a660364fL268-R292) [[4]](diffhunk://#diff-3ca837af0763fb487950289ee9100b94c60cad10d261ee3d8c6696a7a660364fL297-L407)

**Manager and Command Integration:**
* Updated `DataManager.edit_dataset_metadata` to create and execute `EditDatasetMetadataCommand` via the command invoker, supporting undo/redo and showing user feedback for successful edits or errors.
* Added `EditDatasetMetadataCommand` to command test coverage in `tests/commands_tests/test_all_commands_coverage.py`.

**Plotting Widget and Cycler Robustness:**
* Improved initialization and error handling in `plotting_cycler.py` to check for missing `gui` or session references, preventing crashes when GUI state is incomplete. [[1]](diffhunk://#diff-c31292519fd1d12815311ea435e5e838c7867d9f00d6ca03685e412b22fbffa3L77-R77) [[2]](diffhunk://#diff-c31292519fd1d12815311ea435e5e838c7867d9f00d6ca03685e412b22fbffa3L141-R141) [[3]](diffhunk://#diff-c31292519fd1d12815311ea435e5e838c7867d9f00d6ca03685e412b22fbffa3R171-R172) [[4]](diffhunk://#diff-c31292519fd1d12815311ea435e5e838c7867d9f00d6ca03685e412b22fbffa3R194-R198)
* Enhanced error handling in `plotting_widget.py` for widget refreshes, logging warnings for attribute errors instead of silently ignoring them. [[1]](diffhunk://#diff-df3462b7de284c53d83b13bc00177725b2cf923cb4325790e88ae20c72af7fd3L323-R331) [[2]](diffhunk://#diff-df3462b7de284c53d83b13bc00177725b2cf923cb4325790e88ae20c72af7fd3L374-R386)
